### PR TITLE
Add temperature controls to main menu

### DIFF
--- a/src/app/printer-status/printer-status.component.html
+++ b/src/app/printer-status/printer-status.component.html
@@ -1,7 +1,9 @@
 <table class="printer-status" *ngIf="printerStatus">
     <tr>
         <td class="printer-status__value printer-status__value-1"
-            [ngClass]="{'printer-status__no-set-value': printerStatus.nozzle.set === 0}">
+            [ngClass]="{'printer-status__no-set-value': printerStatus.nozzle.set === 0}"
+            (click)="showQuickControlHotend()"
+            matRipple [matRippleUnbounded]="false">
             <img src="assets/nozzle.svg">
             <span class="printer-status__actual-value">{{ printerStatus.nozzle.current }}<span
                     class="printer-status__unit">°C</span></span>
@@ -9,7 +11,9 @@
                 *ngIf="printerStatus.nozzle.set">/{{ printerStatus.nozzle.set }}<span class="unit">°C</span></span>
         </td>
         <td class="printer-status__value printer-status__value-2"
-            [ngClass]="{'printer-status__no-set-value': printerStatus.heatbed.set === 0}">
+            [ngClass]="{'printer-status__no-set-value': printerStatus.heatbed.set === 0}"
+            (click)="showQuickControlHeatbed()"
+            matRipple [matRippleUnbounded]="false">
             <img src="assets/heat-bed.svg">
             <span class="printer-status__actual-value">{{ printerStatus.heatbed.current }}<span
                     class="printer-status__unit">°C</span></span>
@@ -23,3 +27,66 @@
         </td>
     </tr>
 </table>
+<div class="quickControl" *ngIf="view !== QuickControlView.NONE">
+    <table class="top-bar" (click)="hideQuickControl()">
+        <tr>
+            <td class="top-bar__back"><img src="assets/back.svg" class="top-bar__back-icon" />back</td>
+        </tr>
+    </table>
+    <img src="assets/nozzle.svg" class="quickControl__center-icon-small" *ngIf="view === QuickControlView.HOTEND">
+    <img src="assets/heat-bed.svg" class="quickControl__center-icon-small" *ngIf="view === QuickControlView.HEATBED">
+    <div class="quickControl__controller" *ngIf="view === QuickControlView.HOTEND">
+        <div class="quickControl__controller-row">
+            <div class="quickControl__controller-increase" (click)="changeTemperatureHotend(1)"
+                matRipple [matRippleUnbounded]="false">+1
+            </div>
+            <div class="quickControl__controller-increase" (click)="changeTemperatureHotend(10)"
+                matRipple [matRippleUnbounded]="false">+10
+            </div>
+        </div>
+            <div class="quickControl__controller-value" colspan="2">
+                {{ this.newHotendTarget }}<span class="quickControl__controller-value-unit">°C</span>
+            </div>
+        <div class="quickControl__controller-row">
+            <div class="quickControl__controller-decrease" (click)="changeTemperatureHotend(-1)"
+                matRipple [matRippleUnbounded]="false">-1
+            </div>
+            <div class="quickControl__controller-decrease" (click)="changeTemperatureHotend(-10)"
+                matRipple [matRippleUnbounded]="false">-10
+            </div>
+        </div>
+        <div class="quickControl__controller-row">
+            <div class="quickControl__controller-set" colspan="2" (click)="setTemperatureHotend()"
+                matRipple [matRippleUnbounded]="false">
+                    <span class="quickControl__controller-set-span">Set</span>
+            </div>
+        </div>
+    </div>
+    <div class="quickControl__controller" *ngIf="view === QuickControlView.HEATBED">
+        <div class="quickControl__controller-row">
+            <div class="quickControl__controller-increase" (click)="changeTemperatureHeatbed(1)"
+                matRipple [matRippleUnbounded]="false">+1
+            </div>
+            <div class="quickControl__controller-increase" (click)="changeTemperatureHeatbed(10)"
+                matRipple [matRippleUnbounded]="false">+10
+            </div>
+        </div>
+            <div class="quickControl__controller-value" colspan="2">
+                {{ this.newHeatbedTarget }}<span class="quickControl__controller-value-unit">°C</span>
+            </div>
+        <div class="quickControl__controller-row">
+            <div class="quickControl__controller-decrease" (click)="changeTemperatureHeatbed(-1)"
+                matRipple [matRippleUnbounded]="false">-1
+            </div>
+            <div class="quickControl__controller-decrease" (click)="changeTemperatureHeatbed(-10)"
+                matRipple [matRippleUnbounded]="false">-10
+            </div>
+        </div>
+        <div class="quickControl__controller-row">
+            <div class="quickControl__controller-set" colspan="2" (click)="setTemperatureHeatbed()"
+                matRipple [matRippleUnbounded]="false">
+                    <span class="quickControl__controller-set-span">Set</span>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/printer-status/printer-status.component.html
+++ b/src/app/printer-status/printer-status.component.html
@@ -20,7 +20,9 @@
             <span class="printer-status__set-value"
                 *ngIf="printerStatus.heatbed.set">/{{ printerStatus.heatbed.set }}<span class="unit">°C</span></span>
         </td>
-        <td class="printer-status__value printer-status__value-3 printer-status__no-set-value">
+        <td class="printer-status__value printer-status__value-3 printer-status__no-set-value"
+            (click)="showQuickControlFan()"
+            matRipple [matRippleUnbounded]="false">
             <img src="assets/fan.svg">
             <span class="printer-status__actual-value">{{ printerStatus.fan }}<span
                     class="printer-status__unit">%</span></span>
@@ -35,6 +37,7 @@
     </table>
     <img src="assets/nozzle.svg" class="quickControl__center-icon-small" *ngIf="view === QuickControlView.HOTEND">
     <img src="assets/heat-bed.svg" class="quickControl__center-icon-small" *ngIf="view === QuickControlView.HEATBED">
+    <img src="assets/fan.svg" class="quickControl__center-icon-small" *ngIf="view === QuickControlView.FAN">
     <div class="quickControl__controller" *ngIf="view === QuickControlView.HOTEND">
         <div class="quickControl__controller-row">
             <div class="quickControl__controller-increase" (click)="changeTemperatureHotend(1)"
@@ -84,6 +87,33 @@
         </div>
         <div class="quickControl__controller-row">
             <div class="quickControl__controller-set" colspan="2" (click)="setTemperatureHeatbed()"
+                matRipple [matRippleUnbounded]="false">
+                    <span class="quickControl__controller-set-span">Set</span>
+            </div>
+        </div>
+    </div>
+    <div class="quickControl__controller" *ngIf="view === QuickControlView.FAN">
+        <div class="quickControl__controller-row">
+            <div class="quickControl__controller-increase" (click)="changeSpeedFan(1)"
+                matRipple [matRippleUnbounded]="false">+1
+            </div>
+            <div class="quickControl__controller-increase" (click)="changeSpeedFan(10)"
+                matRipple [matRippleUnbounded]="false">+10
+            </div>
+        </div>
+            <div class="quickControl__controller-value" colspan="2">
+                {{ this.newFanTarget }}<span class="quickControl__controller-value-unit">%</span>
+            </div>
+        <div class="quickControl__controller-row">
+            <div class="quickControl__controller-decrease" (click)="changeSpeedFan(-1)"
+                matRipple [matRippleUnbounded]="false">-1
+            </div>
+            <div class="quickControl__controller-decrease" (click)="changeSpeedFan(-10)"
+                matRipple [matRippleUnbounded]="false">-10
+            </div>
+        </div>
+        <div class="quickControl__controller-row">
+            <div class="quickControl__controller-set" colspan="2" (click)="setSpeedFan()"
                 matRipple [matRippleUnbounded]="false">
                     <span class="quickControl__controller-set-span">Set</span>
             </div>

--- a/src/app/printer-status/printer-status.component.scss
+++ b/src/app/printer-status/printer-status.component.scss
@@ -75,3 +75,88 @@
         }
     }
 }
+
+.quickControl {
+    position: fixed;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, .85);
+    z-index: 1000;
+
+    &__center-icon {
+        width: 22vw;
+        display: block;
+        text-align: center;
+        margin-top: 8vh;
+        margin-bottom: 7vh;
+        margin-left: calc(50% - 11vw);
+
+        &-small {
+            display: block;
+            width: 7.5vw;
+            margin: -9vw auto 0;
+        }
+    }
+
+    &__close {
+        display: block;
+        width: 6vw;
+        position: absolute;
+        right: 2vw;
+        top: 3vh;
+    }
+
+    &__controller {
+        width: 35vw;
+        margin: 0 auto;
+        border: solid .6vw;
+        border-radius: 3vw;
+        margin-top: 5vh;
+
+        &-row {
+            display: flex;
+        }
+
+        &-value {
+            padding: 3vh 6vw;
+            font-size: 8vw;
+            font-weight: 500;
+            text-align: center;
+
+            &-unit {
+                text-align: center;
+                font-size: 4vw;
+                font-weight: 400;
+            }
+        }
+
+        &-increase {
+            padding: 3vh 6vw;
+            font-weight: 500;
+            //font-size: 4vw;
+            flex: 1;
+        }
+
+        &-decrease {
+            padding: 3vh 6vw;
+            font-weight: 500;
+            //font-size: 4vw;
+            flex: 1;
+        }
+
+        &-set {
+            height: 10vw;
+            border-top: solid .6vw;
+            flex: 1;
+            align-items: center;
+            display: flex;
+
+            &-span {
+                text-align: center;
+                flex: 1;
+            }
+        }
+    }
+}

--- a/src/app/printer-status/printer-status.component.ts
+++ b/src/app/printer-status/printer-status.component.ts
@@ -17,6 +17,7 @@ export class PrinterStatusComponent implements OnInit, OnDestroy {
     public view = QuickControlView.NONE;
     public newHotendTarget = 200;
     public newHeatbedTarget = 60;
+    public newFanTarget = 100;
 
     public constructor(
         private printerService: PrinterService,
@@ -66,6 +67,10 @@ export class PrinterStatusComponent implements OnInit, OnDestroy {
         this.view = QuickControlView.HEATBED;
     }
 
+    public showQuickControlFan(): void {
+        this.view = QuickControlView.FAN;
+    }
+
     public hideQuickControl(): void {
         this.view = QuickControlView.NONE;
     }
@@ -90,6 +95,16 @@ export class PrinterStatusComponent implements OnInit, OnDestroy {
         }
     }
 
+    public changeSpeedFan(value: number): void {
+        this.newFanTarget += value;
+        if (this.newFanTarget < 0) {
+            this.newFanTarget = 0;
+        }
+        if (this.newFanTarget > 100) {
+            this.newFanTarget = 100;
+        }
+    }
+
     public setTemperatureHotend(): void {
         this.printerService.setTemperatureHotend(this.newHotendTarget);
         this.view = QuickControlView.NONE;
@@ -97,6 +112,11 @@ export class PrinterStatusComponent implements OnInit, OnDestroy {
 
     public setTemperatureHeatbed(): void {
         this.printerService.setTemperatureHeatbed(this.newHeatbedTarget);
+        this.view = QuickControlView.NONE;
+    }
+
+    public setSpeedFan(): void {
+        this.printerService.executeGCode("M106 S" + Math.round(this.newFanTarget / 100 * 255));
         this.view = QuickControlView.NONE;
     }
 }
@@ -111,4 +131,5 @@ enum QuickControlView {
     NONE,
     HOTEND,
     HEATBED,
+    FAN,
 }

--- a/src/app/printer-status/printer-status.component.ts
+++ b/src/app/printer-status/printer-status.component.ts
@@ -13,6 +13,10 @@ export class PrinterStatusComponent implements OnInit, OnDestroy {
     private subscriptions: Subscription = new Subscription();
     public printerStatus: PrinterStatus;
     public status: string;
+    public QuickControlView = QuickControlView;
+    public view = QuickControlView.NONE;
+    public newHotendTarget = 200;
+    public newHeatbedTarget = 60;
 
     public constructor(
         private printerService: PrinterService,
@@ -53,10 +57,58 @@ export class PrinterStatusComponent implements OnInit, OnDestroy {
     public ngOnDestroy(): void {
         this.subscriptions.unsubscribe();
     }
+
+    public showQuickControlHotend(): void {
+        this.view = QuickControlView.HOTEND;
+    }
+
+    public showQuickControlHeatbed(): void {
+        this.view = QuickControlView.HEATBED;
+    }
+
+    public hideQuickControl(): void {
+        this.view = QuickControlView.NONE;
+    }
+
+    public changeTemperatureHotend(value: number): void {
+        this.newHotendTarget += value;
+        if (this.newHotendTarget < 0) {
+            this.newHotendTarget = 0;
+        }
+        if (this.newHotendTarget > 999) {
+            this.newHotendTarget = 999;
+        }
+    }
+
+    public changeTemperatureHeatbed(value: number): void {
+        this.newHeatbedTarget += value;
+        if (this.newHeatbedTarget < 0) {
+            this.newHeatbedTarget = 0;
+        }
+        if (this.newHeatbedTarget > 999) {
+            this.newHeatbedTarget = 999;
+        }
+    }
+
+    public setTemperatureHotend(): void {
+        this.printerService.setTemperatureHotend(this.newHotendTarget);
+        this.view = QuickControlView.NONE;
+    }
+
+    public setTemperatureHeatbed(): void {
+        this.printerService.setTemperatureHeatbed(this.newHeatbedTarget);
+        this.view = QuickControlView.NONE;
+    }
 }
 
 export interface PrinterStatus {
     nozzle: PrinterValue;
     heatbed: PrinterValue;
     fan: number | string;
+}
+
+enum QuickControlView {
+    NONE,
+    HOTEND,
+    HEATBED,
 }


### PR DESCRIPTION
![Set Hotend Temperature](https://user-images.githubusercontent.com/1828970/77206841-dfa3bf80-6aef-11ea-90f5-1e04b63872ba.png)
**Features Added**
This allows hotend and heatbed temperatures to be set from the main menu by clicking on their status icon/temperature.

While this could be managed from the control menu, I like having the preheat and cooldown buttons on there to set both hotend and heatbed temperatures. This allows control of each individually from the main menu, for example to set just the hotend temperature to remove the filament without also heating up the bed.

**Potential Improvements**
To save having to increment up from 0, I've set a default starting value of 200 for the hotend and 60 for the heatbed. This could be something retrieved from config to let users set their own default value.

This only adds the ability to adjust temperatures. It would make sense to also allow fan speed control in the same way. However I couldn't see an easy way already implemented to set fan speed so I've added temperature controls for now.