### PR TITLE
Fix errors and unnecessary data shown when printing from SD

### DIFF
--- a/src/app/job-status/job-status.component.html
+++ b/src/app/job-status/job-status.component.html
@@ -5,9 +5,9 @@
         <div class="job-info__progress-percentage">{{ job.progress }}<span style="font-size: 40%">%</span></div>
     </div>
     <span class="job-info__filename">{{ job.filename }}</span> <br />
-    <span class="job-info__filament">{{ job.filamentAmount }}g Filament</span> <br />
-    <span class="job-info__time"><span
-            class="job-info__time-left">{{ job.timeLeft.value }}</span>{{ job.timeLeft.unit }} left,
+    <span class="job-info__filament" *ngIf="job.filamentAmount !== null">{{ job.filamentAmount }}g Filament</span> <br />
+    <span class="job-info__time"><span *ngIf="job.timeLeft.value !== null"><span
+            class="job-info__time-left">{{ job.timeLeft.value }}</span>{{ job.timeLeft.unit }} left,</span>
         elapsed: {{ job.timePrinted.value }}{{ job.timePrinted.unit }}</span>
 </div>
 <div class="job-info__file-loaded" *ngIf="job && !isPrinting() && isFileLoaded()" (swipe)="cancelLoadedFile()">

--- a/src/app/job.service.ts
+++ b/src/app/job.service.ts
@@ -38,18 +38,18 @@ export class JobService {
                         async (data: OctoprintJobAPI): Promise<void> => {
                             let job: Job = null;
                             if (data.job && data.job.file.name) {
-                                this.printing = ['Printing', 'Pausing', 'Paused', 'Cancelling'].includes(data.state);
+                                this.printing = ['Printing', 'Pausing', 'Paused', 'Cancelling', 'Printing from SD'].includes(data.state);
                                 try {
                                     job = {
                                         status: data.state,
                                         filename: data.job.file.display.replace('.gcode', '').replace('.ufp', ''),
-                                        thumbnail: await this.fileService.getThumbnail(data.job.file.path),
+                                        thumbnail: (data.job.file.origin == 'sdcard') ? undefined : await this.fileService.getThumbnail(data.job.file.path),
                                         progress: Math.round((data.progress.filepos / data.job.file.size) * 100),
-                                        filamentAmount: this.service.convertFilamentLengthToAmount(
+                                        filamentAmount: (data.job.filament === null) ? null : this.service.convertFilamentLengthToAmount(
                                             this.getTotalAmountOfFilament(data.job.filament),
                                         ),
                                         timeLeft: {
-                                            value: this.service.convertSecondsToHours(data.progress.printTimeLeft),
+                                            value: (data.progress.printTimeLeft === null) ? null : this.service.convertSecondsToHours(data.progress.printTimeLeft),
                                             unit: 'h',
                                         },
                                         timePrinted: {

--- a/src/app/layer-progress/layer-progress.component.html
+++ b/src/app/layer-progress/layer-progress.component.html
@@ -1,3 +1,3 @@
-<span class="layer-indication" *ngIf="layerProgress">
+<span class="layer-indication" *ngIf="layerProgress && !(layerProgress.current === 0 && layerProgress.total === 0)">
     Layer <span class="layer-indication__current-layer">{{ layerProgress.current }}</span> of {{ layerProgress.total }}
 </span>


### PR DESCRIPTION
When printing from SD, a thumbnail image should not be retrieved as the filename does not exist in OctoPrint.

Null values should be propagated through to the view instead of replaced with 0. This way values which are not available when printing from SD (listed below, or any other situation also resulting in it being null) can be hidden.

 - Filament used
- Time remaining, until OctoPrint has estimated a time remaining based on current print progress, otherwise it shows 0 remaining for the first minute or so of printing, which looks odd
- Layer progress, which shows as layer 0 of 0

Fixes #541