### PR TITLE
Change thumbnail to [hidden]?

### DIFF
--- a/src/app/job-status/job-status.component.html
+++ b/src/app/job-status/job-status.component.html
@@ -2,9 +2,9 @@
     <div class="job-info__progress-ring" (click)="showPreview = !showPreview">
         <round-progress [current]="job.progress" [max]="100" [stroke]="25" [rounded]="true" [responsive]="true"
             [color]="'#44bd32'"></round-progress>
-        <div class="job-info__progress-percentage" *ngIf="!job.thumbnail || !showPreview()">{{ job.progress }}<span
+        <div class="job-info__progress-percentage" [hidden]="job.thumbnail && showPreview()">{{ job.progress }}<span
                 style="font-size: 40%">%</span></div>
-        <img *ngIf="job.thumbnail && showPreview()" class="job-info__progress-preview" [src]="job.thumbnail" />
+        <img [hidden]="!job.thumbnail || !showPreview()" class="job-info__progress-preview" [src]="job.thumbnail" />
     </div>
     <span class="job-info__filename">{{ job.filename }}</span> <br />
     <span class="job-info__filament" *ngIf="job.hasOwnProperty('filamentAmount')">{{ job.filamentAmount }}g Filament</span> <br />

--- a/src/app/job-status/job-status.component.scss
+++ b/src/app/job-status/job-status.component.scss
@@ -33,6 +33,11 @@
             display: block;
         }
     }
+    
+    & [hidden] {
+        display: none;
+    }
+
 
     &__filename {
         font-size: 6vw;


### PR DESCRIPTION
Hi,
this is a rather unusual PR: I want to make some pretty big design changes, but while I of course can publish the custom CSS file, I don't think you don't want to implement it as the main style ;)
One of my big changes is to show the thumbnail all the time (and bigger). Sadly with Angulars "*ngIf" the thumbnail is not hidden but completely gone. So I made these changes which look the same for most of the users, but give the rest the ability to overwrite the `display:none;` and always show the thumbnail.
I hope you consider merging it - but if not, I can understand that. Or maybe you have a better/cleaner solution?

By the way: Here's the first change I made. The file popup now is fullscreen (to better use the small space of my 4" display) and has a translucent blurred background and a big thumbnail.
![screenshot](https://user-images.githubusercontent.com/30938717/82363913-d27f5000-9a0e-11ea-89d9-7a5326a578f9.png)
