### PR TITLE
Fix issue #849; Respect the OctoPrint axis invert flags

### DIFF
--- a/src/app/control/control.component.ts
+++ b/src/app/control/control.component.ts
@@ -1,5 +1,3 @@
-import { HttpClient, HttpErrorResponse } from "@angular/common/http";
-
 import { Component } from "@angular/core";
 import { SafeResourceUrl } from "@angular/platform-browser";
 import { Router } from "@angular/router";
@@ -27,7 +25,6 @@ export class ControlComponent {
   public actionToConfirm: ActionToConfirm;
 
   public constructor(
-    private http: HttpClient,
     private printerService: PrinterService,
     private printerProfileService: PrinterProfileService,
     private octoprintService: OctoprintService,

--- a/src/app/control/control.component.ts
+++ b/src/app/control/control.component.ts
@@ -1,3 +1,5 @@
+import { HttpClient, HttpErrorResponse } from "@angular/common/http";
+
 import { Component } from "@angular/core";
 import { SafeResourceUrl } from "@angular/platform-browser";
 import { Router } from "@angular/router";
@@ -6,6 +8,9 @@ import { ConfigService } from "../config/config.service";
 import { OctoprintService } from "../octoprint.service";
 import { PsuControlService } from "../plugin-service/psu-control.service";
 import { PrinterService } from "../printer.service";
+import { PrinterProfileService } from "../printerprofile.service";
+
+import { OctoprintPrinterProfileAPI } from '../octoprint-api/printerProfileAPI';
 
 @Component({
   selector: "app-control",
@@ -13,6 +18,8 @@ import { PrinterService } from "../printer.service";
   styleUrls: ["./control.component.scss"],
 })
 export class ControlComponent {
+  public printerProfile: OctoprintPrinterProfileAPI;
+
   public jogDistance = 10;
   public customActions = [];
   public showHelp = false;
@@ -20,13 +27,31 @@ export class ControlComponent {
   public actionToConfirm: ActionToConfirm;
 
   public constructor(
+    private http: HttpClient,
     private printerService: PrinterService,
+    private printerProfileService: PrinterProfileService,
     private octoprintService: OctoprintService,
     private configService: ConfigService,
     private psuControlService: PsuControlService,
     private router: Router
-  ) {
+  ) {   
+    
+    this.printerProfile = {
+      name: "_default",
+      model: "unknown",
+      axes: {
+        x: { inverted: false },
+        y: { inverted: false },
+        z: { inverted: false }
+      }
+    };
+
     this.customActions = this.configService.getCustomActions();
+
+    this.printerProfileService.getDefaultPrinterProfile().then((profile) => {
+      this.printerProfile = profile;
+    });
+
   }
 
   public setDistance(distance: number): void {
@@ -34,7 +59,13 @@ export class ControlComponent {
   }
 
   public moveAxis(axis: string, direction: "+" | "-"): void {
+    if (this.printerProfile.axes[axis].inverted == true)
+    {
+      direction = (direction === "+" ? "-" : "+");
+    }
+
     const distance = Number(direction + this.jogDistance);
+
     this.printerService.jog(axis === "x" ? distance : 0, axis === "y" ? distance : 0, axis === "z" ? distance : 0);
   }
 

--- a/src/app/control/control.component.ts
+++ b/src/app/control/control.component.ts
@@ -31,8 +31,7 @@ export class ControlComponent {
     private configService: ConfigService,
     private psuControlService: PsuControlService,
     private router: Router
-  ) {   
-    
+  ) {
     this.printerProfile = {
       name: "_default",
       model: "unknown",
@@ -48,7 +47,6 @@ export class ControlComponent {
     this.printerProfileService.getDefaultPrinterProfile().then((profile) => {
       this.printerProfile = profile;
     });
-
   }
 
   public setDistance(distance: number): void {

--- a/src/app/octoprint-api/printerProfileAPI.ts
+++ b/src/app/octoprint-api/printerProfileAPI.ts
@@ -1,8 +1,4 @@
 export interface OctoprintPrinterProfileAPI {
-
-}
-
-export interface OctoprintPrinterProfileAPI {
   name: string;
   model: string;
   axes: OctoprintPrinterAxis;

--- a/src/app/octoprint-api/printerProfileAPI.ts
+++ b/src/app/octoprint-api/printerProfileAPI.ts
@@ -1,0 +1,19 @@
+export interface OctoprintPrinterProfileAPI {
+
+}
+
+export interface OctoprintPrinterProfileAPI {
+  name: string;
+  model: string;
+  axes: OctoprintPrinterAxis;
+}
+
+export interface OctoprintPrinterAxis {
+  x: OctoprintAxisDetails;
+  y: OctoprintAxisDetails;
+  z: OctoprintAxisDetails;
+}
+
+export interface OctoprintAxisDetails {
+  inverted: boolean;
+}

--- a/src/app/printerprofile.service.ts
+++ b/src/app/printerprofile.service.ts
@@ -1,8 +1,7 @@
 import { HttpClient, HttpErrorResponse } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { Router } from "@angular/router";
-import { Observable, Observer, Subscription, timer } from "rxjs";
-import { shareReplay } from "rxjs/operators";
+import { Subscription } from "rxjs";
 
 import { ConfigService } from "./config/config.service";
 import { NotificationService } from "./notification/notification.service";

--- a/src/app/printerprofile.service.ts
+++ b/src/app/printerprofile.service.ts
@@ -31,8 +31,7 @@ export class PrinterProfileService {
       this.httpGETRequest = this.http
         .get(this.configService.getURL("printerprofiles/_default"), this.configService.getHTTPHeaders())
         .subscribe(
-          (data: OctoprintPrinterProfileAPI): void => {
-            const printerProfile: OctoprintPrinterProfileAPI = data;
+          (printerProfile: OctoprintPrinterProfileAPI): void => {
             resolve(printerProfile);
           },
           (error: HttpErrorResponse): void => {

--- a/src/app/printerprofile.service.ts
+++ b/src/app/printerprofile.service.ts
@@ -14,27 +14,15 @@ import { OctoprintPrinterProfileAPI } from "./octoprint-api/printerProfileAPI";
   providedIn: "root",
 })
 export class PrinterProfileService {
-  private printerStatusService: PrinterService;
   private httpGETRequest: Subscription;
-  private observable: Observable<OctoprintPrinterProfileAPI>;
-  private observer: Observer<OctoprintPrinterProfileAPI>;
-
+  
   public constructor(
     private http: HttpClient,
     private configService: ConfigService,
     private notificationService: NotificationService,
-    private printerService: PrinterService,
+    private printerStatusService: PrinterService,
     private router: Router
-  ) {
-    this.printerStatusService = printerService;
-    this.observable = new Observable((observer: Observer<OctoprintPrinterProfileAPI>): void => {
-      this.observer = observer;
-    }).pipe(shareReplay(1));
-  }
-
-  public getObservable(): Observable<OctoprintPrinterProfileAPI> {
-    return this.observable;
-  }
+  ) { }
 
   public getDefaultPrinterProfile(): Promise<OctoprintPrinterProfileAPI> {
     return new Promise((resolve): void => {
@@ -46,7 +34,6 @@ export class PrinterProfileService {
         .subscribe(
           (data: OctoprintPrinterProfileAPI): void => {
             const printerProfile: OctoprintPrinterProfileAPI = data;
-            this.observer.next(printerProfile);
             resolve(printerProfile);
           },
           (error: HttpErrorResponse): void => {
@@ -70,10 +57,8 @@ export class PrinterProfileService {
               });
               resolve(printerProfile);
             } else if (error.status === 0 && this.notificationService.getBootGrace()) {
-              this.observer.next(printerProfile);
               resolve(printerProfile);
             } else {
-              this.observer.next(printerProfile);
               resolve(printerProfile);
               this.notificationService.setError("Can't retrieve printer status!", error.message);
             }

--- a/src/app/printerprofile.service.ts
+++ b/src/app/printerprofile.service.ts
@@ -14,7 +14,7 @@ import { OctoprintPrinterProfileAPI } from "./octoprint-api/printerProfileAPI";
 })
 export class PrinterProfileService {
   private httpGETRequest: Subscription;
-  
+
   public constructor(
     private http: HttpClient,
     private configService: ConfigService,
@@ -24,7 +24,7 @@ export class PrinterProfileService {
   ) { }
 
   public getDefaultPrinterProfile(): Promise<OctoprintPrinterProfileAPI> {
-    return new Promise((resolve): void => {
+    return new Promise((resolve, reject): void => {
       if (this.httpGETRequest) {
         this.httpGETRequest.unsubscribe();
       }
@@ -35,16 +35,6 @@ export class PrinterProfileService {
             resolve(printerProfile);
           },
           (error: HttpErrorResponse): void => {
-            const printerProfile: OctoprintPrinterProfileAPI = {
-              name: "_default",
-              model: "unknown",
-              axes: {
-                x: { inverted: false },
-                y: { inverted: false },
-                z: { inverted: false }
-              }
-            };
-
             if (error.status === 409) {
               this.printerStatusService.isPrinterOffline().then((printerOffline): void => {
                 if (printerOffline) {
@@ -53,12 +43,12 @@ export class PrinterProfileService {
                   this.notificationService.setError("Can't retrieve printer profile!", error.message);
                 }
               });
-              resolve(printerProfile);
-            } else if (error.status === 0 && this.notificationService.getBootGrace()) {
-              resolve(printerProfile);
+              reject();
             } else {
-              resolve(printerProfile);
-              this.notificationService.setError("Can't retrieve printer status!", error.message);
+              reject();
+              if (error.status === 0 && this.notificationService.getBootGrace()) {
+                this.notificationService.setError("Can't retrieve printer status!", error.message);
+              }
             }
           }
         );

--- a/src/app/printerprofile.service.ts
+++ b/src/app/printerprofile.service.ts
@@ -1,0 +1,85 @@
+import { HttpClient, HttpErrorResponse } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { Router } from "@angular/router";
+import { Observable, Observer, Subscription, timer } from "rxjs";
+import { shareReplay } from "rxjs/operators";
+
+import { ConfigService } from "./config/config.service";
+import { NotificationService } from "./notification/notification.service";
+import { PrinterService } from "./printer.service";
+
+import { OctoprintPrinterProfileAPI } from "./octoprint-api/printerProfileAPI";
+
+@Injectable({
+  providedIn: "root",
+})
+export class PrinterProfileService {
+  private printerStatusService: PrinterService;
+  private httpGETRequest: Subscription;
+  private observable: Observable<OctoprintPrinterProfileAPI>;
+  private observer: Observer<OctoprintPrinterProfileAPI>;
+
+  public constructor(
+    private http: HttpClient,
+    private configService: ConfigService,
+    private notificationService: NotificationService,
+    private printerService: PrinterService,
+    private router: Router
+  ) {
+    this.printerStatusService = printerService;
+    this.observable = new Observable((observer: Observer<OctoprintPrinterProfileAPI>): void => {
+      this.observer = observer;
+    }).pipe(shareReplay(1));
+  }
+
+  public getObservable(): Observable<OctoprintPrinterProfileAPI> {
+    return this.observable;
+  }
+
+  public getDefaultPrinterProfile(): Promise<OctoprintPrinterProfileAPI> {
+    return new Promise((resolve): void => {
+      if (this.httpGETRequest) {
+        this.httpGETRequest.unsubscribe();
+      }
+      this.httpGETRequest = this.http
+        .get(this.configService.getURL("printerprofiles/_default"), this.configService.getHTTPHeaders())
+        .subscribe(
+          (data: OctoprintPrinterProfileAPI): void => {
+            const printerProfile: OctoprintPrinterProfileAPI = data;
+            this.observer.next(printerProfile);
+            resolve(printerProfile);
+          },
+          (error: HttpErrorResponse): void => {
+            const printerProfile: OctoprintPrinterProfileAPI = {
+              name: "_default",
+              model: "unknown",
+              axes: {
+                x: { inverted: false },
+                y: { inverted: false },
+                z: { inverted: false }
+              }
+            };
+
+            if (error.status === 409) {
+              this.printerStatusService.isPrinterOffline().then((printerOffline): void => {
+                if (printerOffline) {
+                  this.router.navigate(["/standby"]);
+                } else {
+                  this.notificationService.setError("Can't retrieve printer profile!", error.message);
+                }
+              });
+              resolve(printerProfile);
+            } else if (error.status === 0 && this.notificationService.getBootGrace()) {
+              this.observer.next(printerProfile);
+              resolve(printerProfile);
+            } else {
+              this.observer.next(printerProfile);
+              resolve(printerProfile);
+              this.notificationService.setError("Can't retrieve printer status!", error.message);
+            }
+          }
+        );
+    });
+  }
+
+}


### PR DESCRIPTION
I went ahead and took a stab at fixing the issue where the OctoPrint axis inversion setting was not being respected in the in the printer control view.

- Created PrinterProfileService
- Implemented getDefaultPrinterProfile()
- When Control view loads it gets the default printer profile, and subsequent axis moves take the "inverted" setting into account

Fixes #849.