### PR TITLE
Add timeout while loading files

### DIFF
--- a/src/app/files.service.ts
+++ b/src/app/files.service.ts
@@ -13,6 +13,7 @@ import { OctoprintFilesAPI, OctoprintFolderAPI, OctoprintFolderContentAPI } from
 })
 export class FilesService {
   private httpGETRequest: Subscription;
+  private httpGETRequestTimeout: number;
   private httpPOSTRequest: Subscription;
   private httpDELETERequest: Subscription;
 
@@ -25,6 +26,11 @@ export class FilesService {
 
   public getFolder(folderPath = "/"): Promise<(File | Folder)[]> {
     return new Promise((resolve, reject): void => {
+      this.httpGETRequestTimeout = setTimeout(() => {
+        this.httpGETRequest.unsubscribe();
+        this.notificationService.setError("Can't retrieve folder!", "Operation timed out. Please try again.");
+        reject();
+      }, 6000);
       folderPath = folderPath === "/" ? "" : folderPath;
       if (this.httpGETRequest) {
         this.httpGETRequest.unsubscribe();
@@ -122,6 +128,9 @@ export class FilesService {
               this.notificationService.setError("Can't retrieve folder!", error.message);
               reject();
             }
+          },
+          (): void => {
+            clearTimeout(this.httpGETRequestTimeout);
           }
         );
     });


### PR DESCRIPTION
If nothing is returned from the API within 6s an error will be shown. While this is not optimal it should work for now. Fixes #698.