### PR TITLE
fix/Updated filament in NOX theme.

### DIFF
--- a/themes/NOX/custom-styles.css
+++ b/themes/NOX/custom-styles.css
@@ -180,6 +180,25 @@ ngx-spinner .overlay{
     width: 5vw!important;
 }
 
+/************************************** FILAMENT **************************************/
+
+.filament tr{
+    background-color: #222222!important;
+    width: 90vw!important;
+}
+
+.filament-filaments {
+    width: 95.5vw!important;
+}
+
+.filament-filaments::before {
+    display:none!important;
+}
+
+.filament-filaments__name {
+    width: 62vw!important;
+}
+
 /**************************************** FILE ****************************************/
 
 .file{


### PR DESCRIPTION
Filament screen corrected with the following changes:
* Filament tr background colour changed to match theme.
* Filament table background gradient removed.
* Filament tr width adjusted to match files section, this also lined up
the scroll bar with its background.
* Filament name width reduced to prevent filament weight being 
run off the screen. 