### PR TITLE
Focus Theme: Fixed Filament selector screen

### DIFF
--- a/themes/theGarbz/Focus/README.md
+++ b/themes/theGarbz/Focus/README.md
@@ -1,4 +1,4 @@
-# Focus theme v0.1
+# Focus theme v0.2
 
 This theme is based on the classy [NOX theme](../../NOX/) by NoxHirsch and has been modified to Focus on highlighting the most important information for a user. The goal was to create a theme that could easily be read from a distance. Some of the features are listed below:
 * High contrast display of relevant information (e.g. print time, temperature)
@@ -52,5 +52,10 @@ Please note: This theme like the theme it was based on makes use of more CSS eff
 
    ![Settings](screenshots/screenshot_menu.png)
 
+### Version History:
 
+__v0.2:__
+* Fixed bug which prevented the filament weight from being shown in the filament selector.
 
+__v0.1:__
+* Initial Issue

--- a/themes/theGarbz/Focus/custom-styles.css
+++ b/themes/theGarbz/Focus/custom-styles.css
@@ -212,7 +212,7 @@ ngx-spinner .overlay{
 }
 
 .filament-filaments__name {
-    width: 62vw!important;
+    width: 59.5vw!important;
 }
 
 app-filament .scroll__thumb-inactive {
@@ -697,7 +697,7 @@ round-progress svg circle{
 }
 
 .settings__version::after{
-    content: " \00a0 | \00a0 Focus theme v0.1";
+    content: " \00a0 | \00a0 Focus theme v0.2";
     width: auto!important;
 }
 


### PR DESCRIPTION
Width was slightly too wide so the weight remaining
was not being displayed correcty. Also updated version info.