### PR TITLE
Add support for TPLinkSmartPlug plugin

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -40,10 +40,6 @@ export class AppComponent implements OnInit {
     if (this.configService && this.configService.isInitialized()) {
       if (this.configService.isLoaded()) {
         if (this.configService.isValid()) {
-          // TODO: this call is only here to allow migration path on `turnOnPrinterWhenExitingSleep`
-          //       option release.
-          this.migratePSUControlOption();
-
           this.waitForOctoprint();
         } else {
           this.checkInvalidConfig();
@@ -60,7 +56,7 @@ export class AppComponent implements OnInit {
     const errors = this.configService.getErrors();
 
     if (this.service.hasUpdateError(errors)) {
-      if (this.service.autoFixErrors(errors)) {
+      if (this.service.fixUpdateErrors(errors)) {
         this.initialize();
       } else {
         this.configService.setUpdate();
@@ -129,17 +125,5 @@ export class AppComponent implements OnInit {
     //     );
     //   })
     //   .finally(() => clearTimeout(showPrinterConnectedTimeout));
-  }
-
-  // TODO: this method is only here to allow migration path on `turnOnPrinterWhenExitingSleep`
-  //       option release, which can break current PSUControl behaviour.
-  //       It will be removed when all people have used a release with this fix.
-  private migratePSUControlOption() {
-    const config = this.configService.getCurrentConfig();
-    if (config.plugins.psuControl.turnOnPSUWhenExitingSleep) {
-      config.octodash.turnOnPrinterWhenExitingSleep = true;
-      config.plugins.psuControl.turnOnPSUWhenExitingSleep = false;
-      this.configService.saveConfig(config);
-    }
   }
 }

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -35,13 +35,15 @@ export class AppService {
         (config.plugins.tpLinkSmartPlug = { enabled: true, smartPlugIP: '127.0.0.1' }),
       ".octodash should have required property 'previewProgressCircle'": config =>
         (config.octodash.previewProgressCircle = false),
-      ".octodash should have required property 'turnOnPrinterWhenExitingSleep'": config =>
-        (config.octodash.turnOnPrinterWhenExitingSleep = false),
+      ".octodash should have required property 'turnOnPrinterWhenExitingSleep'": config => {
+        config.octodash.turnOnPrinterWhenExitingSleep = config.plugins.psuControl.turnOnPSUWhenExitingSleep ?? false;
+        delete config.plugins.psuControl.turnOnPSUWhenExitingSleep;
+      },
     };
   }
 
-  // If the errors can be automatically fixed return true here
-  public autoFixErrors(errors: string[]): boolean {
+  // If all errors can be automatically fixed return true here
+  public fixUpdateErrors(errors: string[]): boolean {
     const config = this.configService.getCurrentConfig();
 
     let fullyAutofixed = true;

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -1,7 +1,9 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import _ from 'lodash';
 import { ElectronService } from 'ngx-electron';
 
+import { Config } from './config/config.model';
 import { ConfigService } from './config/config.service';
 import { NotificationService } from './notification/notification.service';
 
@@ -9,7 +11,7 @@ import { NotificationService } from './notification/notification.service';
   providedIn: 'root',
 })
 export class AppService {
-  private updateError: string[];
+  private updateError: Record<string, (config: Config) => void>;
   private loadedFile = false;
   public version: string;
   public latestVersion: string;
@@ -25,19 +27,33 @@ export class AppService {
     this.enableVersionListener();
     this.enableCustomCSSListener();
     this.electronService.ipcRenderer.send('appInfo');
-    this.updateError = [
-      ".printer should have required property 'zBabystepGCode'",
-      ".octodash should have required property 'previewProgressCircle'",
-    ];
+
+    // list of all error following an upgrade
+    this.updateError = {
+      ".printer should have required property 'zBabystepGCode'": config => (config.printer.zBabystepGCode = 'M290 Z'),
+      ".plugins should have required property 'tpLinkSmartPlug'": config =>
+        (config.plugins.tpLinkSmartPlug = { enabled: true, smartPlugIP: '127.0.0.1' }),
+      ".octodash should have required property 'previewProgressCircle'": config =>
+        (config.octodash.previewProgressCircle = false),
+      ".octodash should have required property 'turnOnPrinterWhenExitingSleep'": config =>
+        (config.octodash.turnOnPrinterWhenExitingSleep = false),
+    };
   }
 
   // If the errors can be automatically fixed return true here
-  public autoFixError(): boolean {
+  public autoFixErrors(errors: string[]): boolean {
     const config = this.configService.getCurrentConfig();
-    config.printer.zBabystepGCode = 'M290 Z';
-    config.octodash.previewProgressCircle = false;
+
+    let fullyAutofixed = true;
+    for (const error of errors) {
+      if (_.hasIn(this.updateError, error)) {
+        this.updateError[error](config);
+      } else {
+        fullyAutofixed = false;
+      }
+    }
     this.configService.saveConfig(config);
-    return true;
+    return fullyAutofixed;
   }
 
   private enableVersionListener(): void {
@@ -89,8 +105,8 @@ export class AppService {
     this.electronService.ipcRenderer.send('screenWakeup');
   }
 
-  public getUpdateError(): string[] {
-    return this.updateError;
+  public hasUpdateError(errors: string[]): boolean {
+    return _.intersection(errors, _.keys(this.updateError)).length > 0;
   }
 
   public setLoadedFile(value: boolean): void {

--- a/src/app/config/config.default.ts
+++ b/src/app/config/config.default.ts
@@ -48,6 +48,11 @@ export const defaultConfig: Config = {
       enabled: false,
       turnOnPSUWhenExitingSleep: false,
     },
+    tpLinkSmartPlug: {
+      enabled: false,
+      smartPlugIP: '127.0.0.1',
+      turnOnPowerWhenExitingSleep: false,
+    },
   },
   octodash: {
     customActions: [

--- a/src/app/config/config.default.ts
+++ b/src/app/config/config.default.ts
@@ -105,6 +105,7 @@ export const defaultConfig: Config = {
     pollingInterval: 2000,
     touchscreen: true,
     turnScreenOffWhileSleeping: false,
+    turnOnPrinterWhenExitingSleep: false,
     preferPreviewWhilePrinting: false,
     previewProgressCircle: false,
   },

--- a/src/app/config/config.default.ts
+++ b/src/app/config/config.default.ts
@@ -51,7 +51,6 @@ export const defaultConfig: Config = {
     tpLinkSmartPlug: {
       enabled: false,
       smartPlugIP: '127.0.0.1',
-      turnOnPowerWhenExitingSleep: false,
     },
   },
   octodash: {

--- a/src/app/config/config.model.ts
+++ b/src/app/config/config.model.ts
@@ -68,6 +68,8 @@ interface EnclosurePlugin extends Plugin {
 }
 
 interface PSUControlPlugin extends Plugin {
+  // TODO: this option still exists to allow migration path... need to be removed
+  // when the new `turnOnPSUWhenExitingSleep` will be released
   turnOnPSUWhenExitingSleep: boolean;
 }
 
@@ -81,6 +83,7 @@ interface OctoDash {
   pollingInterval: number;
   touchscreen: boolean;
   turnScreenOffWhileSleeping: boolean;
+  turnOnPrinterWhenExitingSleep: boolean;
   preferPreviewWhilePrinting: boolean;
   previewProgressCircle: boolean;
 }

--- a/src/app/config/config.model.ts
+++ b/src/app/config/config.model.ts
@@ -73,7 +73,6 @@ interface PSUControlPlugin extends Plugin {
 
 interface TPLinkSmartPlugPlugin extends Plugin {
   smartPlugIP: string;
-  turnOnPowerWhenExitingSleep: boolean;
 }
 
 interface OctoDash {

--- a/src/app/config/config.model.ts
+++ b/src/app/config/config.model.ts
@@ -54,6 +54,7 @@ interface Plugins {
   preheatButton: Plugin;
   printTimeGenius: Plugin;
   psuControl: PSUControlPlugin;
+  tpLinkSmartPlug: TPLinkSmartPlugPlugin;
 }
 
 interface Plugin {
@@ -68,6 +69,11 @@ interface EnclosurePlugin extends Plugin {
 
 interface PSUControlPlugin extends Plugin {
   turnOnPSUWhenExitingSleep: boolean;
+}
+
+interface TPLinkSmartPlugPlugin extends Plugin {
+  smartPlugIP: string;
+  turnOnPowerWhenExitingSleep: boolean;
 }
 
 interface OctoDash {

--- a/src/app/config/config.model.ts
+++ b/src/app/config/config.model.ts
@@ -70,7 +70,7 @@ interface EnclosurePlugin extends Plugin {
 interface PSUControlPlugin extends Plugin {
   // TODO: this option still exists to allow migration path... need to be removed
   // when the new `turnOnPSUWhenExitingSleep` will be released
-  turnOnPSUWhenExitingSleep: boolean;
+  turnOnPSUWhenExitingSleep?: boolean;
 }
 
 interface TPLinkSmartPlugPlugin extends Plugin {

--- a/src/app/config/config.schema.ts
+++ b/src/app/config/config.schema.ts
@@ -202,7 +202,7 @@ export const configSchema = {
         tpLinkSmartPlug: {
           $id: '#/properties/plugins/properties/tpLinkSmartPlug',
           type: 'object',
-          required: ['enabled', 'smartPlugIP', 'turnOnPowerWhenExitingSleep'],
+          required: ['enabled', 'smartPlugIP'],
           properties: {
             enabled: {
               $id: '#/properties/plugins/properties/tpLinkSmartPlug/properties/enabled',
@@ -211,10 +211,6 @@ export const configSchema = {
             smartPlugIP: {
               $id: '#/properties/plugins/properties/tpLinkSmartPlug/properties/smartPlugIP',
               type: 'string',
-            },
-            turnOnPowerWhenExitingSleep: {
-              $id: '#/properties/plugins/properties/turnOnPowerWhenExitingSleep',
-              type: 'boolean',
             },
           },
         },

--- a/src/app/config/config.schema.ts
+++ b/src/app/config/config.schema.ts
@@ -187,14 +187,10 @@ export const configSchema = {
         psuControl: {
           $id: '#/properties/plugins/properties/psuControl',
           type: 'object',
-          required: ['enabled', 'turnOnPSUWhenExitingSleep'],
+          required: ['enabled'],
           properties: {
             enabled: {
               $id: '#/properties/plugins/properties/printTimeGenius/properties/enabled',
-              type: 'boolean',
-            },
-            turnOnPSUWhenExitingSleep: {
-              $id: '#/properties/plugins/properties/turnOnPSUWhenExitingSleep',
               type: 'boolean',
             },
           },
@@ -225,6 +221,7 @@ export const configSchema = {
         'pollingInterval',
         'touchscreen',
         'turnScreenOffWhileSleeping',
+        'turnOnPrinterWhenExitingSleep',
         'preferPreviewWhilePrinting',
         'previewProgressCircle',
       ],
@@ -290,6 +287,10 @@ export const configSchema = {
         },
         turnScreenOffWhileSleeping: {
           $id: '#/properties/octodash/properties/turnScreenOffWhileSleeping',
+          type: 'boolean',
+        },
+        turnOnPrinterWhenExitingSleep: {
+          $id: '#/properties/octodash/properties/turnOnPrinterWhenExitingSleep',
           type: 'boolean',
         },
         preferPreviewWhilePrinting: {

--- a/src/app/config/config.schema.ts
+++ b/src/app/config/config.schema.ts
@@ -111,6 +111,7 @@ export const configSchema = {
         'preheatButton',
         'printTimeGenius',
         'psuControl',
+        'tpLinkSmartPlug',
       ],
       properties: {
         displayLayerProgress: {
@@ -194,6 +195,25 @@ export const configSchema = {
             },
             turnOnPSUWhenExitingSleep: {
               $id: '#/properties/plugins/properties/turnOnPSUWhenExitingSleep',
+              type: 'boolean',
+            },
+          },
+        },
+        tpLinkSmartPlug: {
+          $id: '#/properties/plugins/properties/tpLinkSmartPlug',
+          type: 'object',
+          required: ['enabled', 'smartPlugIP', 'turnOnPowerWhenExitingSleep'],
+          properties: {
+            enabled: {
+              $id: '#/properties/plugins/properties/tpLinkSmartPlug/properties/enabled',
+              type: 'boolean',
+            },
+            smartPlugIP: {
+              $id: '#/properties/plugins/properties/tpLinkSmartPlug/properties/smartPlugIP',
+              type: 'string',
+            },
+            turnOnPowerWhenExitingSleep: {
+              $id: '#/properties/plugins/properties/turnOnPowerWhenExitingSleep',
               type: 'boolean',
             },
           },

--- a/src/app/config/config.service.ts
+++ b/src/app/config/config.service.ts
@@ -80,7 +80,7 @@ export class ConfigService {
 
   public getErrors(): string[] {
     const errors = [];
-    this.validator.errors.forEach((error): void => {
+    this.validator.errors?.forEach((error): void => {
       if (error.keyword === 'type') {
         errors.push(`${error.dataPath} ${error.message}`);
       } else {
@@ -97,6 +97,7 @@ export class ConfigService {
       const configStored = this.store.get('config');
       if (this.validateGiven(configStored)) {
         this.config = config;
+        this.valid = true;
         this.generateHttpHeaders();
         return null;
       } else {

--- a/src/app/config/config.service.ts
+++ b/src/app/config/config.service.ts
@@ -193,8 +193,8 @@ export class ConfigService {
     return this.config.octodash.turnScreenOffWhileSleeping;
   }
 
-  public turnOnPSUWhenExitingSleep(): boolean {
-    return this.config.plugins.psuControl.turnOnPSUWhenExitingSleep;
+  public getAutomaticPrinterPowerOn(): boolean {
+    return this.config.octodash.turnOnPrinterWhenExitingSleep;
   }
 
   public useTpLinkSmartPlug(): boolean {

--- a/src/app/config/config.service.ts
+++ b/src/app/config/config.service.ts
@@ -197,14 +197,13 @@ export class ConfigService {
     return this.config.plugins.psuControl.turnOnPSUWhenExitingSleep;
   }
 
+  public useTpLinkSmartPlug(): boolean {
+    return this.config.plugins.tpLinkSmartPlug.enabled;
+  }
+
   public getSmartPlugIP(): string {
     return this.config.plugins.tpLinkSmartPlug.smartPlugIP;
   }
-
-  public turnOnPowerWhenExitingSleep(): boolean {
-    return this.config.plugins.tpLinkSmartPlug.turnOnPowerWhenExitingSleep;
-  }
-
   public getFilamentThickness(): number {
     return this.config.filament.thickness;
   }

--- a/src/app/config/config.service.ts
+++ b/src/app/config/config.service.ts
@@ -197,6 +197,14 @@ export class ConfigService {
     return this.config.plugins.psuControl.turnOnPSUWhenExitingSleep;
   }
 
+  public getSmartPlugIP(): string {
+    return this.config.plugins.tpLinkSmartPlug.smartPlugIP;
+  }
+
+  public turnOnPowerWhenExitingSleep(): boolean {
+    return this.config.plugins.tpLinkSmartPlug.turnOnPowerWhenExitingSleep;
+  }
+
   public getFilamentThickness(): number {
     return this.config.filament.thickness;
   }

--- a/src/app/config/setup/plugins/plugins.component.html
+++ b/src/app/config/setup/plugins/plugins.component.html
@@ -36,5 +36,11 @@
     </span>
     PSU Control
   </div>
-  <div class="setup__explanation">Enclosure and PSU Control Plugin can be configured further in the settings.</div>
+  <div class="setup__checkbox-container" (click)="changeTPLinkSmartPlugPlugin()">
+    <span class="setup__checkbox">
+      <span class="setup__checkbox-checked" *ngIf="tplinkSmartPlugPlugin"></span>
+    </span>
+    TPLink-SmartPlug
+  </div>
+  <div class="setup__explanation">Enclosure, PSU Control and TPLink-SmartPlug plugins can be configured further in the settings.</div>
 </div>

--- a/src/app/config/setup/plugins/plugins.component.ts
+++ b/src/app/config/setup/plugins/plugins.component.ts
@@ -12,6 +12,7 @@ export class PluginsComponent {
   @Input() preheatButtonPlugin: boolean;
   @Input() printTimeGeniusPlugin: boolean;
   @Input() psuControlPlugin: boolean;
+  @Input() tplinkSmartPlugPlugin: boolean;
 
   @Output() displayLayerProgressPluginChange = new EventEmitter<boolean>();
   @Output() enclosurePluginChange = new EventEmitter<boolean>();
@@ -19,6 +20,7 @@ export class PluginsComponent {
   @Output() preheatButtonPluginChange = new EventEmitter<boolean>();
   @Output() printTimeGeniusPluginChange = new EventEmitter<boolean>();
   @Output() psuControlPluginChange = new EventEmitter<boolean>();
+  @Output() tplinkSmartPlugPluginChange = new EventEmitter<boolean>();
 
   public changeDisplayLayerProgressPlugin(): void {
     this.displayLayerProgressPlugin = !this.displayLayerProgressPlugin;
@@ -48,5 +50,10 @@ export class PluginsComponent {
   public changePsuControlPlugin(): void {
     this.psuControlPlugin = !this.psuControlPlugin;
     this.psuControlPluginChange.emit(this.psuControlPlugin);
+  }
+
+  public changeTPLinkSmartPlugPlugin(): void {
+    this.tplinkSmartPlugPlugin = !this.tplinkSmartPlugPlugin;
+    this.tplinkSmartPlugPluginChange.emit(this.tplinkSmartPlugPlugin);
   }
 }

--- a/src/app/config/setup/setup.component.html
+++ b/src/app/config/setup/setup.component.html
@@ -60,6 +60,7 @@
     [(preheatButtonPlugin)]="config.plugins.preheatButton.enabled"
     [(printTimeGeniusPlugin)]="config.plugins.printTimeGenius.enabled"
     [(psuControlPlugin)]="config.plugins.psuControl.enabled"
+    [(tplinkSmartPlugPlugin)]="config.plugins.tplinkSmartPlug.enabled"
   ></app-config-setup-plugins>
 
   <div *ngIf="page === 6">

--- a/src/app/control/control.component.ts
+++ b/src/app/control/control.component.ts
@@ -7,6 +7,7 @@ import { OctoprintService } from '../octoprint.service';
 import { OctoprintPrinterProfile } from '../octoprint/model/printerProfile';
 import { EnclosureService } from '../plugin-service/enclosure.service';
 import { PsuControlService } from '../plugin-service/psu-control.service';
+import { TPLinkSmartPlugService } from '../plugin-service/tplink-smartplug.service';
 import { PrinterService } from '../printer.service';
 import { PrinterProfileService } from '../printerprofile.service';
 
@@ -31,6 +32,7 @@ export class ControlComponent {
     private configService: ConfigService,
     private psuControlService: PsuControlService,
     private enclosureService: EnclosureService,
+    private tplinkSmartPlugService: TPLinkSmartPlugService,
     private router: Router,
   ) {
     this.printerProfile = {
@@ -120,6 +122,12 @@ export class ControlComponent {
         break;
       case '[!POWERTOGGLE]':
         this.psuControlService.togglePSU();
+        break;
+      case '[!TPLINKOFF]':
+        this.tplinkSmartPlugService.changePowerState(false);
+        break;
+      case '[!TPLINKON]':
+        this.tplinkSmartPlugService.changePowerState(true);
         break;
       default: {
         if (command.includes('[!WEB]')) {

--- a/src/app/plugin-service/tplink-smartplug.service.ts
+++ b/src/app/plugin-service/tplink-smartplug.service.ts
@@ -1,0 +1,38 @@
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Subscription } from 'rxjs';
+
+import { ConfigService } from '../config/config.service';
+import { NotificationService } from '../notification/notification.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TPLinkSmartPlugService {
+  private httpPOSTRequest: Subscription;
+
+  public constructor(
+    private configService: ConfigService,
+    private notificationService: NotificationService,
+    private http: HttpClient,
+  ) {}
+
+  public changePowerState(on: boolean): void {
+    if (this.httpPOSTRequest) {
+      this.httpPOSTRequest.unsubscribe();
+    }
+
+    const payload = {
+      command: on ? 'turnOn' : 'turnOff',
+      ip: this.configService.getSmartPlugIP(),
+    };
+    this.httpPOSTRequest = this.http
+      .post(this.configService.getURL('plugin/tplinksmartplug'), payload, this.configService.getHTTPHeaders())
+      .subscribe(
+        (): void => null,
+        (error: HttpErrorResponse): void => {
+          this.notificationService.setError("Can't control TPLink SmartPlug!", error.message);
+        },
+      );
+  }
+}

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -310,6 +310,23 @@
           <br />
           <div
             class="settings__checkbox-container"
+            [ngClass]="{ 'settings__checkbox-container-disabled': !(config.plugins.psuControl.enabled || config.plugins.tpLinkSmartPlug.enabled) }"
+            (click)="
+              config.octodash.turnOnPrinterWhenExitingSleep = !config.octodash.turnOnPrinterWhenExitingSleep
+            "
+          >
+            <span class="settings__checkbox">
+              <span
+                class="settings__checkbox-checked"
+                [ngClass]="{ 'settings__checkbox-checked-disabled': !(config.plugins.psuControl.enabled || config.plugins.tpLinkSmartPlug.enabled) }"
+                *ngIf="config.octodash.turnOnPrinterWhenExitingSleep"
+              ></span>
+            </span>
+            <span class="settings__checkbox-descriptor">Turn on printer when exiting sleep</span>
+          </div>
+          <br />
+          <div
+            class="settings__checkbox-container"
             (click)="config.octodash.preferPreviewWhilePrinting = !config.octodash.preferPreviewWhilePrinting"
           >
             <span class="settings__checkbox">
@@ -550,22 +567,6 @@
               <span class="settings__checkbox-checked" *ngIf="config.plugins.psuControl.enabled"></span>
             </span>
             <span class="settings__checkbox-descriptor">enabled</span>
-          </div>
-          <div
-            class="settings__checkbox-container"
-            [ngClass]="{ 'settings__checkbox-container-disabled': !config.plugins.psuControl.enabled }"
-            (click)="
-              config.plugins.psuControl.turnOnPSUWhenExitingSleep = !config.plugins.psuControl.turnOnPSUWhenExitingSleep
-            "
-          >
-            <span class="settings__checkbox">
-              <span
-                class="settings__checkbox-checked"
-                [ngClass]="{ 'settings__checkbox-checked-disabled': !config.plugins.psuControl.enabled }"
-                *ngIf="config.plugins.psuControl.turnOnPSUWhenExitingSleep"
-              ></span>
-            </span>
-            <span class="settings__checkbox-descriptor">Turn on PSU when exiting sleep</span>
           </div>
           <span class="settings__heading-2">TPLink-SmartPlug</span>
           <div

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -567,6 +567,43 @@
             </span>
             <span class="settings__checkbox-descriptor">Turn on PSU when exiting sleep</span>
           </div>
+          <span class="settings__heading-2">TPLink-SmartPlug</span>
+          <div
+            class="settings__checkbox-container"
+            (click)="config.plugins.tpLinkSmartPlug.enabled = !config.plugins.tpLinkSmartPlug.enabled"
+          >
+            <span class="settings__checkbox">
+              <span class="settings__checkbox-checked" *ngIf="config.plugins.tpLinkSmartPlug.enabled"></span>
+            </span>
+            <span class="settings__checkbox-descriptor">enabled</span>
+          </div>
+          <div
+            class="settings__checkbox-container"
+            [ngClass]="{ 'settings__checkbox-container-disabled': !config.plugins.tplinkSmartPlug.enabled }"
+            (click)="
+              config.plugins.tplinkSmartPlug.turnOnPowerWhenExitingSleep = !config.plugins.tplinkSmartPlug.turnOnPowerWhenExitingSleep
+            "
+          >
+            <span class="settings__checkbox">
+              <span
+                class="settings__checkbox-checked"
+                [ngClass]="{ 'settings__checkbox-checked-disabled': !config.plugins.tplinkSmartPlug.enabled }"
+                *ngIf="config.plugins.tplinkSmartPlug.turnOnPowerWhenExitingSleep"
+              ></span>
+            </span>
+            <span class="settings__checkbox-descriptor">Turn on TPLink when exiting sleep</span>
+          </div>
+          <label for="smart-plug-ip" class="settings__input-label">Smart plug IP</label>
+          <input
+            type="text"
+            id="smart-plug-ip"
+            class="settings__input"
+            name="smart-plug-ip"
+            style="width: 44.94vw"
+            [(ngModel)]="config.plugins.tpLinkSmartPlug.smartPlugIP"
+            required
+            [disabled]="!config.plugins.tpLinkSmartPlug.enabled"
+          />
         </div>
       </div>
       <div class="settings__content settings__content-inactive" #settingsCredits>

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -577,23 +577,7 @@
             </span>
             <span class="settings__checkbox-descriptor">enabled</span>
           </div>
-          <div
-            class="settings__checkbox-container"
-            [ngClass]="{ 'settings__checkbox-container-disabled': !config.plugins.tplinkSmartPlug.enabled }"
-            (click)="
-              config.plugins.tplinkSmartPlug.turnOnPowerWhenExitingSleep = !config.plugins.tplinkSmartPlug.turnOnPowerWhenExitingSleep
-            "
-          >
-            <span class="settings__checkbox">
-              <span
-                class="settings__checkbox-checked"
-                [ngClass]="{ 'settings__checkbox-checked-disabled': !config.plugins.tplinkSmartPlug.enabled }"
-                *ngIf="config.plugins.tplinkSmartPlug.turnOnPowerWhenExitingSleep"
-              ></span>
-            </span>
-            <span class="settings__checkbox-descriptor">Turn on TPLink when exiting sleep</span>
-          </div>
-          <label for="smart-plug-ip" class="settings__input-label">Smart plug IP</label>
+          <label for="smart-plug-ip" class="settings__input-label">SmartPlug IP</label>
           <input
             type="text"
             id="smart-plug-ip"

--- a/src/app/standby/standby.component.ts
+++ b/src/app/standby/standby.component.ts
@@ -39,7 +39,7 @@ export class StandbyComponent implements OnInit {
 
   public reconnect(): void {
     this.connecting = true;
-    if (this.configService.turnOnPSUWhenExitingSleep()) {
+    if (this.configService.getAutomaticPrinterPowerOn()) {
       if (this.configService.useTpLinkSmartPlug()) {
         this.tpLinkSmartPlugService.changePowerState(true);
       } else {

--- a/src/app/standby/standby.component.ts
+++ b/src/app/standby/standby.component.ts
@@ -40,10 +40,11 @@ export class StandbyComponent implements OnInit {
   public reconnect(): void {
     this.connecting = true;
     if (this.configService.turnOnPSUWhenExitingSleep()) {
-      this.psuControlService.changePSUState(true);
-      setTimeout(this.checkConnection.bind(this), 5000);
-    } else if (this.configService.turnOnPowerWhenExitingSleep()) {
-      this.tpLinkSmartPlugService.changePowerState(true);
+      if (this.configService.useTpLinkSmartPlug()) {
+        this.tpLinkSmartPlugService.changePowerState(true);
+      } else {
+        this.psuControlService.changePSUState(true);
+      }
       setTimeout(this.checkConnection.bind(this), 5000);
     } else {
       this.checkConnection();

--- a/src/app/standby/standby.component.ts
+++ b/src/app/standby/standby.component.ts
@@ -7,6 +7,7 @@ import { AppService } from '../app.service';
 import { ConfigService } from '../config/config.service';
 import { NotificationService } from '../notification/notification.service';
 import { PsuControlService } from '../plugin-service/psu-control.service';
+import { TPLinkSmartPlugService } from '../plugin-service/tplink-smartplug.service';
 
 @Component({
   selector: 'app-standby',
@@ -26,6 +27,7 @@ export class StandbyComponent implements OnInit {
     private service: AppService,
     private notificationService: NotificationService,
     private psuControlService: PsuControlService,
+    private tpLinkSmartPlugService: TPLinkSmartPlugService,
   ) {}
 
   public ngOnInit(): void {
@@ -39,6 +41,9 @@ export class StandbyComponent implements OnInit {
     this.connecting = true;
     if (this.configService.turnOnPSUWhenExitingSleep()) {
       this.psuControlService.changePSUState(true);
+      setTimeout(this.checkConnection.bind(this), 5000);
+    } else if (this.configService.turnOnPowerWhenExitingSleep()) {
+      this.tpLinkSmartPlugService.changePowerState(true);
       setTimeout(this.checkConnection.bind(this), 5000);
     } else {
       this.checkConnection();


### PR DESCRIPTION
Add the support for TP Link as alternative of PSU Controler plugin (and fix the issue #1244).

It implements 2 custom actions (`[!TPLINKOFF]` and `[!TPLINKON]`) and an option to power on the smartplug when the standby mode exits. I tested these changes on my RPi 3B (and on my laptop) and it seems working without any issues (this is barely a copy/paste of the PSU plugin, without the toggle feature).

Unfortunately, we need a keyboard to setup the IP address in the settings menu (or edit the `config.json` file).

Closes #1244 