### PR TITLE
Add klipper support for changing filament

### DIFF
--- a/src/app/config/config.default.ts
+++ b/src/app/config/config.default.ts
@@ -9,6 +9,7 @@ export const defaultConfig: Config = {
     name: '',
     xySpeed: 150,
     zSpeed: 5,
+    disableExtruderGCode: 'M18 E',
     zBabystepGCode: 'M290 Z',
     defaultTemperatureFanSpeed: {
       hotend: 200,

--- a/src/app/config/config.model.ts
+++ b/src/app/config/config.model.ts
@@ -27,6 +27,7 @@ interface Printer {
   name: string;
   xySpeed: number;
   zSpeed: number;
+  disableExtruderGCode: string;
   zBabystepGCode: string;
   defaultTemperatureFanSpeed: DefaultTemperatureFanSpeed;
 }

--- a/src/app/config/config.schema.ts
+++ b/src/app/config/config.schema.ts
@@ -25,7 +25,7 @@ export const configSchema = {
     printer: {
       $id: '#/properties/printer',
       type: 'object',
-      required: ['name', 'xySpeed', 'zSpeed', 'zBabystepGCode', 'defaultTemperatureFanSpeed'],
+      required: ['name', 'xySpeed', 'zSpeed', 'disableExtruderGCode', 'zBabystepGCode', 'defaultTemperatureFanSpeed'],
       properties: {
         name: {
           $id: '#/properties/printer/properties/name',
@@ -39,6 +39,11 @@ export const configSchema = {
         zSpeed: {
           $id: '#/properties/printer/properties/zSpeed',
           type: 'integer',
+        },
+        disableExtruderGCode: {
+          $id: '#/properties/printer/properties/disableExtruderGCode',
+          type: 'string',
+          pattern: '^(.*)$',
         },
         zBabystepGCode: {
           $id: '#/properties/printer/properties/zBabystepGCode',

--- a/src/app/config/config.service.ts
+++ b/src/app/config/config.service.ts
@@ -269,6 +269,10 @@ export class ConfigService {
     return this.config.octoprint.accessToken;
   }
 
+  public getDisableExtruderGCode(): string {
+    return this.config.printer.disableExtruderGCode;
+  }
+
   public getZBabystepGCode(): string {
     return this.config.printer.zBabystepGCode;
   }

--- a/src/app/filament/change-filament/change-filament.component.ts
+++ b/src/app/filament/change-filament/change-filament.component.ts
@@ -28,7 +28,7 @@ export class ChangeFilamentComponent implements OnInit {
   }
 
   private disableExtruderStepper(): void {
-    this.printerService.executeGCode('M18 E ');
+    this.printerService.executeGCode(`${this.configService.getDisableExtruderGCode()}`);
   }
 
   private initiateM600FilamentChange(): void {


### PR DESCRIPTION
Hi, it's a simple implementation to allow custom gcode to disable the extruder. Using Klipper, M18 would disable all steppers, ignoring arguments.
At first I had added a "klipper support" checkbox into Settings, however I then chose to implement it just like the babystepping option, for the sake of consistency and flexibility. So I added a 'disableExtruderGCode' key, changable in the config.json (default value is 'M18 E'). For Klipper I use "SET_STEPPER_ENABLE STEPPER=extruder ENABLE=0", I can confirm it works (tried @pause and M0/M1).

Just a note. I had to downgrade electron-store to 6 (can't read config.json otherwise) and electron to 9 ("tilted" display otherwise) to get interface working (even before my changes, on clean setup). Of course I reverted dependencies to original values before commit. I don't know if these are known issues or I did something wrong.
This is my first PR too, hope I did everything right.