### PR TITLE
fix lottie warning

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -17,6 +17,9 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
+            "allowedCommonJsDependencies": [
+              "lottie-web"
+            ],
             "aot": true,
             "outputPath": "dist",
             "index": "src/index.html",


### PR DESCRIPTION
remove lottie warning when building

```
Warning: octodash/src/app/app.module.ts depends on 'lottie-web'. CommonJS or AMD dependencies can cause optimization bailouts.
For more info see: https://angular.io/guide/build#configuring-commonjs-dependencies
```