### PR TITLE
A temporary fix to the Layer Progress indication.

### DIFF
--- a/themes/theGarbz/Focus/README.md
+++ b/themes/theGarbz/Focus/README.md
@@ -54,6 +54,9 @@ Please note: This theme like the theme it was based on makes use of more CSS eff
 
 ### Version History:
 
+__v0.3:__
+* Temporary change in Layer display code to suit new Layer-Progress Component.
+
 __v0.2:__
 * Fixed bug which prevented the filament weight from being shown in the filament selector.
 

--- a/themes/theGarbz/Focus/README.md
+++ b/themes/theGarbz/Focus/README.md
@@ -1,4 +1,4 @@
-# Focus theme v0.2
+# Focus theme v0.3
 
 This theme is based on the classy [NOX theme](../../NOX/) by NoxHirsch and has been modified to Focus on highlighting the most important information for a user. The goal was to create a theme that could easily be read from a distance. Some of the features are listed below:
 * High contrast display of relevant information (e.g. print time, temperature)

--- a/themes/theGarbz/Focus/custom-styles.css
+++ b/themes/theGarbz/Focus/custom-styles.css
@@ -516,25 +516,27 @@ app-job-status ~ app-printer-status .printer-status__value-3 img {
 
 /**************************************** FILE LOADED - LAYER PROGRESS ****************************************/
 
-app-job-status ~ app-height-progress .layer-indication {
+app-height-progress .height-indication {
   position: absolute !important;
   top: 60vh;
   left: 68.8vw;
-  visibility: hidden;
   width: auto !important;
   margin: 0 !important;
-  letter-spacing: -1em;
+  color: var(--dark-text);
+  /*visibility: hidden;
+  letter-spacing: -1em;*/
 }
 
-app-job-status ~ app-height-progress .layer-indication__current-layer {
+app-height-progress .height-indication__current-height {
   position: relative;
   top: -0.5vh !important;
   visibility: visible !important;
   font-size: 5vw !important;
   letter-spacing: normal !important;
+  color: var(--light-text);
 }
 
-app-job-status ~ app-height-progress .layer-indication__total-layers {
+/*app-height-progress .layer-indication__total-height {
   position: relative;
   top: -0.5vh !important;
   visibility: visible !important;
@@ -543,7 +545,7 @@ app-job-status ~ app-height-progress .layer-indication__total-layers {
   color: var(--dark-text);
 }
 
-app-job-status ~ app-height-progress .layer-indication::before {
+app-height-progress .layer-indication::before {
   background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QAAAAAAAD5Q7t/AAAACXBIWXMAAA7EAAAOxAGVKw4bAAADaUlEQVRo3tXZTYhVZRgHcJ1JncyYGEyldKOZRB+QRtGiCVEioWRIQVdthNkKbdy2EHLbUsgWSghtpE0RUQYV1sawD/qAMFIKk/FjRKYanV+Le4Y5HJ/33HvPPddz54G7ued5/s//fd73/d/nuWfJkj4ZVuAojmNlv/L0i/wGfGPBzmJj07w6Jb8LU+60a5homl8Z8aU4hNvSNocjGGqab5H8GD7SuX2GNU3znie/FecDkrN4I/vMBs/PY2vT5F/HzYDc39iR83sBfwZ+/+BgE8TnJTKyL/BQELMGnyZi7p7UBhKZt6NYXhJ7T3aJ54LY/kuttETewL4ucCa0ZLVo/ZFa5RL5C56ogLkFPwR49Uqtcon8AA/0gH0/3k9g9y61eBq/BeC3sh1ZWlORJvFfkOcPPFcVtEwid9ZBvJBvXAWprXLOaql6l9gzVatSdoTerOMIZQJxsOQIPdtrglGcauASf4ixXguUr1JKRn/FkxUwt+DHAK9/HSu241KQ9Ab2d4EzgesBzhRerp14IfkGfJ3Y9k5bicju3tSm1cy9nSDypUFq5rAcjyWeHcBMQOgvjOf8xrPvijaDAwnsp8p2s1Py63FG68dkMuFT+0BjQVbPYH1V8i8GVTsRbbVyqY0slEiswsmC72W8VGUBh8V9+7fYFPgPaf24lQ31tzOfoSC+rDs9XHUXXsGVAPQ6XkvEpKQ2KZHYjatBzDT2VCKfA38E5xKVOYLhIKYotaFEYjjbkWinf5IQjyqLWJmd/8g+wYNBzAjeyT4jwfO1OJ3ADO9aHQuZxL9Bwgt4vgucZ/B7gDOLQ7UTLyTfJi2bbZOXFOFiN0XodRGr8XFi+9/DfUHMvXg3EfM51vWL7JhAh7ML+FbiAn6HzTnfR/F94DeXYURC8Kpe22kLA82cVu+zLPBJSe009mZEriae7wnw8g1fTzNx1OecxtrAd3NW9ajCbXcoh/Mwvir4JvuldgtIDfWXsD3wH8Ex7S11R1INX7IP6+YIFS2pONIqE8ZoeCY+hdEgpii1oUQakJn4ZzwexMxLbSiRGpqJU3/uTmNv4D8slsj9WnN00aawq3biheTtZuJlJbGLYiYe7BccBVJ1vGKqJpE1LmLxvuTLLWJUDTNx04tYvC+6CwvpeiYeONPhTDzQps1MXJf9D/8DEmah7Y5IAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDIwLTA1LTIxVDE3OjUxOjUyKzAwOjAw6dTVAQAAACV0RVh0ZGF0ZTptb2RpZnkAMjAyMC0wNS0yMVQxNzo1MTo1MiswMDowMJiJbb0AAAAZdEVYdFNvZnR3YXJlAHd3dy5pbmtzY2FwZS5vcmeb7jwaAAAAAElFTkSuQmCC');
   visibility: visible !important;
   background-size: 6vw 6vh;
@@ -555,13 +557,14 @@ app-job-status ~ app-height-progress .layer-indication::before {
   filter: brightness(0.7);
 }
 
-app-job-status ~ app-height-progress .layer-indication__current-layer::after {
+app-height-progress .layer-indication__current-layer::after {
   content: '/';
   font-weight: normal;
   padding-left: 0.5vw;
   padding-right: 0.5vw;
   color: var(--dark-text);
-}
+}*/
+
 
 /**************************************** PRINTING ****************************************/
 
@@ -702,7 +705,7 @@ round-progress svg circle {
 }
 
 .settings__version::after {
-  content: ' \00a0 | \00a0 Focus theme v0.2';
+  content: ' \00a0 | \00a0 Focus theme v0.3';
   width: auto !important;
 }
 
@@ -788,7 +791,7 @@ round-progress svg circle {
 
 #action-icon,
 #action-color {
-  width: 21vw !important; /*  14vw*1.5 */
+  width: 21vw !important; /* 14vw*1.5 */
 }
 
 .settings__checkbox-descriptor {


### PR DESCRIPTION
To revert the design to the previous one an additional
class is required for the height-progress to match the
old layer-progress setup. This will be subject to a 
separate pull request. 
Related to #1749 but does not fix the NOX theme. 