### PR TITLE
Re-Added class: Height-progress - total

### DIFF
--- a/src/app/height-progress/height-progress.component.html
+++ b/src/app/height-progress/height-progress.component.html
@@ -18,6 +18,8 @@
     <ng-container i18n="@@height-of">
       of
     </ng-container>
-    {{ height.total >= 0 ? height.total : '---' }}
+    <span class="height-indication__total-height">
+      {{ height.total >= 0 ? height.total : '---' }}
+    </span>
   </span>
 </ng-template>


### PR DESCRIPTION
This class references the total height as was possible by themes in version 2.1.1 (allows fixing the NOX and Focus themes).

@pciavald this class was missing when you converted the layer-progress component to the height-progress component. 

This will facilitate closing of #1749