### PR TITLE
Support PWM Outputs of Enclosure Plug-In

### DIFF
--- a/src/app/model/octoprint/plugins/enclosure.model.ts
+++ b/src/app/model/octoprint/plugins/enclosure.model.ts
@@ -1,5 +1,6 @@
+/* eslint-disable camelcase */
+
 export interface EnclosurePluginAPI {
-  /* eslint-disable camelcase */
   controlled_io: string;
   temp_sensor_address: string;
   temp_sensor_navbar: boolean;
@@ -29,4 +30,8 @@ export interface EnclosureColorBody {
 
 export interface EnclosureOutputBody {
   status: boolean;
+}
+
+export interface EnclosurePWMBody {
+  duty_cycle: number;
 }

--- a/src/app/services/enclosure/enclosure.octoprint.service.ts
+++ b/src/app/services/enclosure/enclosure.octoprint.service.ts
@@ -85,9 +85,9 @@ export class EnclosureOctoprintService implements EnclosureService {
       .subscribe();
   }
 
-  setPWM(identifier: number, duty_cycle: number): void {
+  setPWM(identifier: number, dutyCycle: number): void {
     const pwmBody: EnclosurePWMBody = {
-      duty_cycle,
+      dutyCycle,
     };
     this.http
       .patch(

--- a/src/app/services/enclosure/enclosure.octoprint.service.ts
+++ b/src/app/services/enclosure/enclosure.octoprint.service.ts
@@ -87,7 +87,8 @@ export class EnclosureOctoprintService implements EnclosureService {
 
   setPWM(identifier: number, dutyCycle: number): void {
     const pwmBody: EnclosurePWMBody = {
-      dutyCycle,
+      /* eslint-disable camelcase */
+      duty_cycle: dutyCycle,
     };
     this.http
       .patch(

--- a/src/app/services/enclosure/enclosure.octoprint.service.ts
+++ b/src/app/services/enclosure/enclosure.octoprint.service.ts
@@ -8,6 +8,7 @@ import { PSUState, TemperatureReading } from '../../model';
 import {
   EnclosureColorBody,
   EnclosureOutputBody,
+  EnclosurePWMBody,
   EnclosurePluginAPI,
   PSUControlCommand,
   TasmotaCommand,
@@ -74,6 +75,24 @@ export class EnclosureOctoprintService implements EnclosureService {
       .patch(
         this.configService.getApiURL('plugin/enclosure/outputs/' + identifier, false),
         outputBody,
+        this.configService.getHTTPHeaders(),
+      )
+      .pipe(
+        catchError(error =>
+          this.notificationService.setError($localize`:@@error-set-output:Can't set output!`, error.message),
+        ),
+      )
+      .subscribe();
+  }
+
+  setPWM(identifier: number, duty_cycle: number): void {
+    const pwmBody: EnclosurePWMBody = {
+      duty_cycle,
+    };
+    this.http
+      .patch(
+        this.configService.getApiURL('plugin/enclosure/pwm/' + identifier, false),
+        pwmBody,
         this.configService.getHTTPHeaders(),
       )
       .pipe(

--- a/src/app/services/enclosure/enclosure.octoprint.service.ts
+++ b/src/app/services/enclosure/enclosure.octoprint.service.ts
@@ -8,8 +8,8 @@ import { PSUState, TemperatureReading } from '../../model';
 import {
   EnclosureColorBody,
   EnclosureOutputBody,
-  EnclosurePWMBody,
   EnclosurePluginAPI,
+  EnclosurePWMBody,
   PSUControlCommand,
   TasmotaCommand,
   TasmotaMqttCommand,

--- a/src/app/services/enclosure/enclosure.service.ts
+++ b/src/app/services/enclosure/enclosure.service.ts
@@ -11,6 +11,8 @@ export abstract class EnclosureService {
 
   abstract setOutput(identifier: number, status: boolean): void;
 
+  abstract setPWM(identifier: number, duty_cycle: number): void;
+
   abstract setPSUState(state: PSUState): void;
 
   abstract togglePSU(): void;

--- a/src/app/services/enclosure/enclosure.service.ts
+++ b/src/app/services/enclosure/enclosure.service.ts
@@ -11,7 +11,7 @@ export abstract class EnclosureService {
 
   abstract setOutput(identifier: number, status: boolean): void;
 
-  abstract setPWM(identifier: number, duty_cycle: number): void;
+  abstract setPWM(identifier: number, dutyCycle: number): void;
 
   abstract setPSUState(state: PSUState): void;
 


### PR DESCRIPTION
This adds back-end support for PWM outputs to the `EnclosureService`.

Please also consider enclosure plug-in PWM outputs while working on #1846.