### PR TITLE
Update to all Garbz Themes to suit 2.2.0

### DIFF
--- a/themes/theGarbz/BigFingers/README.md
+++ b/themes/theGarbz/BigFingers/README.md
@@ -1,4 +1,4 @@
-# BigFingers theme v0.2
+# BigFingers theme v0.3
 
 This variation on the standard theme increases the width of the scroll bars to make them easier to touch on small displays.
 No special requirements exist for this theme, however it is intended for small low resolution displays.
@@ -25,6 +25,9 @@ To install copy the custom-styles.css file into the octodash config folder:
 
 
 ### Version History:
+
+__v0.3:__
+* Extra text removed from settings menu which ran off the screen.
 
 __v0.2:__
 * Hitbox of settings button increased.

--- a/themes/theGarbz/BigFingers/custom-styles.css
+++ b/themes/theGarbz/BigFingers/custom-styles.css
@@ -83,10 +83,3 @@ app-filament .scroll__thumb-inactive {
 .settings__content {
     width: 59vw!important;
 }
-
-.settings__made::after {
-    content: "BigFingers theme v0.2 by theGarbz";
-    width: auto!important;
-    font-size: 73%;
-    display: inline-block;
-}

--- a/themes/theGarbz/Focus/README.md
+++ b/themes/theGarbz/Focus/README.md
@@ -1,4 +1,4 @@
-# Focus theme v0.3
+# Focus theme v0.4
 
 This theme is based on the classy [NOX theme](../../NOX/) by NoxHirsch and has been modified to Focus on highlighting the most important information for a user. The goal was to create a theme that could easily be read from a distance. Some of the features are listed below:
 * High contrast display of relevant information (e.g. print time, temperature)
@@ -53,6 +53,11 @@ Please note: This theme like the theme it was based on makes use of more CSS eff
    ![Settings](screenshots/screenshot_menu.png)
 
 ### Version History:
+
+__v0.4:__
+* Fix for Layer display code - Reenables the icon in place of text.
+* Fixed settings items running off the edge of the screen.
+* Fxied settings scroll bars so they no longer run off the bottom of the screen.
 
 __v0.3:__
 * Temporary change in Layer display code to suit new Layer-Progress Component.

--- a/themes/theGarbz/Focus/custom-styles.css
+++ b/themes/theGarbz/Focus/custom-styles.css
@@ -523,8 +523,8 @@ app-height-progress .height-indication {
   width: auto !important;
   margin: 0 !important;
   color: var(--dark-text);
-  /*visibility: hidden;
-  letter-spacing: -1em;*/
+  visibility: hidden;
+  letter-spacing: -1em;
 }
 
 app-height-progress .height-indication__current-height {
@@ -536,7 +536,7 @@ app-height-progress .height-indication__current-height {
   color: var(--light-text);
 }
 
-/*app-height-progress .layer-indication__total-height {
+app-height-progress .height-indication__total-height {
   position: relative;
   top: -0.5vh !important;
   visibility: visible !important;
@@ -545,7 +545,7 @@ app-height-progress .height-indication__current-height {
   color: var(--dark-text);
 }
 
-app-height-progress .layer-indication::before {
+app-height-progress .height-indication::before {
   background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QAAAAAAAD5Q7t/AAAACXBIWXMAAA7EAAAOxAGVKw4bAAADaUlEQVRo3tXZTYhVZRgHcJ1JncyYGEyldKOZRB+QRtGiCVEioWRIQVdthNkKbdy2EHLbUsgWSghtpE0RUQYV1sawD/qAMFIKk/FjRKYanV+Le4Y5HJ/33HvPPddz54G7ued5/s//fd73/d/nuWfJkj4ZVuAojmNlv/L0i/wGfGPBzmJj07w6Jb8LU+60a5homl8Z8aU4hNvSNocjGGqab5H8GD7SuX2GNU3znie/FecDkrN4I/vMBs/PY2vT5F/HzYDc39iR83sBfwZ+/+BgE8TnJTKyL/BQELMGnyZi7p7UBhKZt6NYXhJ7T3aJ54LY/kuttETewL4ucCa0ZLVo/ZFa5RL5C56ogLkFPwR49Uqtcon8AA/0gH0/3k9g9y61eBq/BeC3sh1ZWlORJvFfkOcPPFcVtEwid9ZBvJBvXAWprXLOaql6l9gzVatSdoTerOMIZQJxsOQIPdtrglGcauASf4ixXguUr1JKRn/FkxUwt+DHAK9/HSu241KQ9Ab2d4EzgesBzhRerp14IfkGfJ3Y9k5bicju3tSm1cy9nSDypUFq5rAcjyWeHcBMQOgvjOf8xrPvijaDAwnsp8p2s1Py63FG68dkMuFT+0BjQVbPYH1V8i8GVTsRbbVyqY0slEiswsmC72W8VGUBh8V9+7fYFPgPaf24lQ31tzOfoSC+rDs9XHUXXsGVAPQ6XkvEpKQ2KZHYjatBzDT2VCKfA38E5xKVOYLhIKYotaFEYjjbkWinf5IQjyqLWJmd/8g+wYNBzAjeyT4jwfO1OJ3ADO9aHQuZxL9Bwgt4vgucZ/B7gDOLQ7UTLyTfJi2bbZOXFOFiN0XodRGr8XFi+9/DfUHMvXg3EfM51vWL7JhAh7ML+FbiAn6HzTnfR/F94DeXYURC8Kpe22kLA82cVu+zLPBJSe009mZEriae7wnw8g1fTzNx1OecxtrAd3NW9ajCbXcoh/Mwvir4JvuldgtIDfWXsD3wH8Ex7S11R1INX7IP6+YIFS2pONIqE8ZoeCY+hdEgpii1oUQakJn4ZzwexMxLbSiRGpqJU3/uTmNv4D8slsj9WnN00aawq3biheTtZuJlJbGLYiYe7BccBVJ1vGKqJpE1LmLxvuTLLWJUDTNx04tYvC+6CwvpeiYeONPhTDzQps1MXJf9D/8DEmah7Y5IAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDIwLTA1LTIxVDE3OjUxOjUyKzAwOjAw6dTVAQAAACV0RVh0ZGF0ZTptb2RpZnkAMjAyMC0wNS0yMVQxNzo1MTo1MiswMDowMJiJbb0AAAAZdEVYdFNvZnR3YXJlAHd3dy5pbmtzY2FwZS5vcmeb7jwaAAAAAElFTkSuQmCC');
   visibility: visible !important;
   background-size: 6vw 6vh;
@@ -557,14 +557,12 @@ app-height-progress .layer-indication::before {
   filter: brightness(0.7);
 }
 
-app-height-progress .layer-indication__current-layer::after {
+app-height-progress .height-indication__current-height::after {
   content: '/';
   font-weight: normal;
-  padding-left: 0.5vw;
-  padding-right: 0.5vw;
   color: var(--dark-text);
-}*/
-
+  font-size: 3.5vw !important;
+}
 
 /**************************************** PRINTING ****************************************/
 
@@ -699,14 +697,8 @@ round-progress svg circle {
 
 /**************************************** SETTINGS ****************************************/
 
-.settings__made::after {
-  content: ' \00a0 | \00a0 Focus theme by theGarbz';
-  width: auto !important;
-}
-
-.settings__version::after {
-  content: ' \00a0 | \00a0 Focus theme v0.3';
-  width: auto !important;
+.settings__made {
+  visibility: hidden;
 }
 
 .settings-wrapper {
@@ -730,7 +722,7 @@ round-progress svg circle {
 }
 
 .settings__scroll {
-  height: 85vh !important;
+  height: 83vh !important;
 }
 
 .settings__save {

--- a/themes/theGarbz/Glanceable/README.md
+++ b/themes/theGarbz/Glanceable/README.md
@@ -1,12 +1,12 @@
-# Glanceable theme v0.1
+# Glanceable theme v0.2
 
-This variation on the standard theme includes a nearly full width horizontal progress bar during printing. This makes it far easier to see the progress of a print when glancing at the screen from a distance, hence the name "Glanceable theme". 
+This variation on the standard theme includes a nearly full width horizontal progress bar during printing. This makes it far easier to see the progress of a print when glancing at the screen from a distance, hence the name "Glanceable theme".
 
 To install copy the custom-styles.css file into the octodash config folder:
 ```
 ~/.config/octodash/custom-styles.css
 ```
-Users of Octodash 2.1.1 read the important note below. 
+
 
 ###### Theme by theGarbz.
 
@@ -20,25 +20,10 @@ Users of Octodash 2.1.1 read the important note below.
 
    ![File List](screenshots/screenshot_printing_circle.png)
 
-## Important Note for Octodash 2.1.1 users
+### Version History:
 
-This theme relies on an additional progress percentage element which is not available in Octodash 2.1.1. Using this theme on Octodash 2.1.1 without modification (read on) will result in no progress percentage visible when the horizontal progressbar is displayed. 
+__v0.2:__
+* Theme updated to suit new layer progress layout in Octodash 2.2.0
 
-It is possible to move the progress percentage from the circular progressbar to the horizontal progressbar by __uncommenting the following lines__ in this custom-styles.css:
-
-```
-/*.job-info__progress-percentage {
-    margin-top: -0.3vh!important;
-    margin-left: 0vw!important;
-    font-size: 6.7vh!important;
-    font-weight: 500!important;
-    display:block!important;
-    position:fixed!important;
-    left: 43.4vw!important;
-    top: 77vh!important;
-    z-index:1!important;
-    color:white!important;
-    text-shadow: 1px 1px 4px black;
-}*/
-```
-
+__v0.1:__
+* Initial Issue

--- a/themes/theGarbz/Glanceable/custom-styles.css
+++ b/themes/theGarbz/Glanceable/custom-styles.css
@@ -1,4 +1,3 @@
-
 /**** Job-Info Resizes ****/
 
 app-job-status ~ app-printer-status .printer-status{
@@ -14,18 +13,18 @@ app-job-status ~ app-printer-status .printer-status__set-value {
 
 /**** Job-Info Layer Progress ****/
 
-.layer-indication{
+.height-indication{
     position:absolute!important;
     top: 66vh!important;
     left: 0vw!important;
     font-size: 3vw!important;
 }
 
-.layer-indication__current-layer{
+.height-indication__current-height{
     font-size: 6vh!important;
 }
 
-.layer-indication__total-layers{
+.height-indication__total-height{
     font-size: 5vh!important;
 }
 
@@ -63,43 +62,3 @@ app-job-status ~ app-printer-status .printer-status__set-value {
     text-shadow: 1px 1px 4px black;
     visibility: visible!important;
 }
-
-/**** by-line ****/
-
-.settings-container {
-    height: 86vh!important;
-    top: 8vh!important;
-}
-
-.settings__made::after {
-    content: "Glanceable theme v0.1 by theGarbz";
-    width: auto!important;
-    font-size: 73%;
-    display: inline-block;
-}
-
-/*
- * Version 2.1.1 and previous of Octodash are missing
- * the progress-bar-percentage element. As such the
- * bar renders without showing the percentage complete.
- * to relocate the percentage complete from the
- * circular progress bar to the horizontal progress bar
- * uncomment the following lines.
- *
- * Note: Doing so will remove the percentage number
- * from the circular progress bar. (See Readme.md)
- */
-
-/*.job-info__progress-percentage {
-    margin-top: -0.3vh!important;
-    margin-left: 0vw!important;
-    font-size: 6.7vh!important;
-    font-weight: 500!important;
-    display:block!important;
-    position:fixed!important;
-    left: 43.4vw!important;
-    top: 77vh!important;
-    z-index:1!important;
-    color:white!important;
-    text-shadow: 1px 1px 4px black;
-}*/


### PR DESCRIPTION
All themes updated to suit Layer Progress changes
Additional tweaking to vertical scroll bar height on some themes.
Removed additional by-line as it broke on some themes and isn't part of any upstream checks. 