### PR TITLE
fix RPI OS Bullseye start issue #2531

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -795,7 +795,7 @@ xset s noblank
 xset -dpms
 
 ratpoison&
-octodash
+octodash --no-sandbox
 EOF
 
     cat <<EOF >> ~/.bashrc

--- a/scripts/remove.sh
+++ b/scripts/remove.sh
@@ -11,6 +11,6 @@ sed -i '/xset s off/d' ~/.xinitrc
 sed -i '/xset s noblank/d' ~/.xinitrc
 sed -i '/xset -dpms/d' ~/.xinitrc
 sed -i '/ratpoison&/d' ~/.xinitrc
-sed -i '/octodash/d' ~/.xinitrc
+sed -i '/octodash --no-sandbox/d' ~/.xinitrc
 
 echo "OctoDash has been removed :(. Please review your ~/.xinitrc and ~/.bashrc files to make sure everything got removed properly!"


### PR DESCRIPTION
fix RPI OS Bullseye start issue #2531

The issue is very long, to summarize at this time the only problem left to fix is that OctoDash is missing the "--no-sandbox" flag.

Adding the flag.