### PR TITLE
Allow customizing of the default directory used in the file browser

### DIFF
--- a/helper/config.schema.js
+++ b/helper/config.schema.js
@@ -295,6 +295,7 @@ const configSchema = {
         'screenWakeupCommand',
         'showExtruderControl',
         'showNotificationCenterIcon',
+        'defaultDirectory',
       ],
       properties: {
         customActions: {
@@ -408,6 +409,11 @@ const configSchema = {
         showNotificationCenterIcon: {
           $id: '#/properties/octodash/properties/showNotificationCenterIcon',
           type: 'boolean',
+        },
+        defaultDirectory: {
+          $id: '#/properties/octodash/properties/defaultDirectory',
+          type: 'string',
+          pattern: '^/(.*)$',
         },
       },
     },

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import _ from 'lodash-es';
 
+import { defaultConfig } from './config/config.default';
 import { Config } from './config/config.model';
 import { ConfigService } from './config/config.service';
 import { ElectronService } from './electron.service';
@@ -57,6 +58,8 @@ export class AppService {
       "/plugins must have required property 'ophom'": config => (config.plugins.ophom = { enabled: false }),
       "/octodash must have required property 'showNotificationCenterIcon'": config =>
         (config.octodash.showNotificationCenterIcon = true),
+      "/octodash must have required property 'defaultDirectory'": config =>
+        (config.octodash.defaultDirectory = defaultConfig.octodash.defaultDirectory),
     };
   }
 

--- a/src/app/config/config.default.ts
+++ b/src/app/config/config.default.ts
@@ -135,5 +135,6 @@ export const defaultConfig: Config = {
     screenWakeupCommand: 'xset s off && xset -dpms && xset s noblank',
     showExtruderControl: true,
     showNotificationCenterIcon: true,
+    defaultDirectory: '/',
   },
 };

--- a/src/app/config/config.model.ts
+++ b/src/app/config/config.model.ts
@@ -106,6 +106,7 @@ interface OctoDash {
   screenWakeupCommand: string;
   showExtruderControl: boolean;
   showNotificationCenterIcon: boolean;
+  defaultDirectory: string;
 }
 
 export interface CustomAction {

--- a/src/app/config/config.service.ts
+++ b/src/app/config/config.service.ts
@@ -338,4 +338,8 @@ export class ConfigService {
   public showNotificationCenterIcon(): boolean {
     return this.config.octodash.showNotificationCenterIcon;
   }
+
+  public getDefaultDirectory(): string {
+    return this.config.octodash.defaultDirectory;
+  }
 }

--- a/src/app/files/files.component.ts
+++ b/src/app/files/files.component.ts
@@ -37,7 +37,7 @@ export class FilesComponent {
   ) {
     this.showLoader();
     this.directory = { files: [], folders: [] };
-    this.currentFolder = '/';
+    this.currentFolder = this.configService.getDefaultDirectory();
 
     this.sortingAttribute = this.configService.getDefaultSortingAttribute();
     this.sortingOrder = this.configService.getDefaultSortingOrder();

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -361,7 +361,9 @@
             <span class="settings__checkbox-descriptor" i18n="@@always-circular">Always use circular progress bar</span>
           </div>
           <form class="settings__form">
-            <label for="defaultDirectory" class="settings__input-label" i18n="@@default-directory">Default directory for file browser</label>
+            <label for="defaultDirectory" class="settings__input-label" i18n="@@default-directory"
+              >Default directory for file browser</label
+            >
             <input
               type="text"
               id="defaultDirectory"

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -360,6 +360,17 @@
             </span>
             <span class="settings__checkbox-descriptor" i18n="@@always-circular">Always use circular progress bar</span>
           </div>
+          <form class="settings__form">
+            <label for="defaultDirectory" class="settings__input-label" i18n="@@default-directory">Default directory for file browser</label>
+            <input
+              type="text"
+              id="defaultDirectory"
+              class="settings__input"
+              name="defaultDirectory"
+              style="width: 44.94vw"
+              [(ngModel)]="config.octodash.defaultDirectory"
+              required />
+          </form>
           <br />
           <span class="settings__heading-2" i18n="@@invert-axis-control">Invert Axis Control</span>
           <div


### PR DESCRIPTION
This eliminates the need to select `sdcard` or `local` every time, and if you keep your files in some deeper path for whatever reason this helps with that too.