### PR TITLE
Fix version comparison

### DIFF
--- a/helper/discover.js
+++ b/helper/discover.js
@@ -1,12 +1,19 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable import/no-commonjs */
 
-const compareVersions = require('compare-versions');
+const { compare } = require('compare-versions');
 const exec = require('child_process').exec;
 
 const minimumVersion = '1.3.5';
 let browser;
 let nodes = [];
+
+function compareVersions(left, right, direction) {
+  function fixVersion(v) {
+    return v.replace('rc', '-rc').replace('--rc', '-rc');
+  }
+  return compare(fixVersion(left), fixVersion(right), direction);
+}
 
 function startDiscovery(window) {
   exec('hostname', (err, stdout) => {
@@ -29,7 +36,7 @@ function discoverNodes(window, localDomain) {
       version: service.txt.version,
       url: `http://${service.host.replace(/\.$/, '')}:${service.port}${service.txt.path}`,
       local: service.host === localDomain,
-      disable: compareVersions(minimumVersion, service.txt.version) === -1,
+      disabled: compareVersions(minimumVersion, service.txt.version, '>'),
     });
     sendNodes(window);
   });

--- a/src/app/config/setup/discover-octoprint/discover-octoprint.component.html
+++ b/src/app/config/setup/discover-octoprint/discover-octoprint.component.html
@@ -3,10 +3,19 @@
 </span>
 <div *ngIf="!manualURL">
   <div class="discover-octoprint__wrapper">
-    <span *ngFor="let node of octoprintNodes" class="discover-octoprint__node" (click)="setOctoprintInstance(node)">
+    <span
+      *ngFor="let node of octoprintNodes"
+      class="discover-octoprint__node"
+      [ngClass]="{
+        'discover-octoprint__node-disabled': node.disabled,
+      }"
+      (click)="setOctoprintInstance(node)">
       <div class="discover-octoprint__node-name">
         {{ node.name }}
         <br />
+        <span class="discover-octoprint__node-upgrade" i18n="@@octoprint-upgrade-required" *ngIf="node.disabled">
+          Upgrade Required /
+        </span>
         <span class="discover-octoprint__node-details" i18n="@@version-url">
           Version {{ node.version }}, URL: {{ node.url }}
         </span>

--- a/src/app/config/setup/discover-octoprint/discover-octoprint.component.scss
+++ b/src/app/config/setup/discover-octoprint/discover-octoprint.component.scss
@@ -21,6 +21,12 @@
     margin-bottom: 2vh;
     padding: 2vh 2vw;
 
+    &-disabled {
+      pointer-events: none;
+      opacity: 50%;
+      font-style: italic;
+    }
+
     &-name {
       white-space: nowrap;
       text-overflow: ellipsis;
@@ -32,6 +38,11 @@
     &-details {
       font-size: 0.55rem;
       opacity: 0.7;
+    }
+
+    &-upgrade {
+      font-size: 0.55rem;
+      font-weight: bold;
     }
 
     &-connect-icon {

--- a/src/app/config/setup/discover-octoprint/discover-octoprint.component.ts
+++ b/src/app/config/setup/discover-octoprint/discover-octoprint.component.ts
@@ -91,5 +91,5 @@ interface OctoprintNodes {
   version: string;
   url: string;
   local: boolean;
-  disable: boolean;
+  disabled: boolean;
 }


### PR DESCRIPTION
This PR fixes version comparison when checking if OctoPrint is at the minimum version.  This also adds better UI indications when an upgrade is required.
