### PR TITLE
Display release title

### DIFF
--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -151,7 +151,7 @@ export class AppService {
     return this.version;
   }
 
-  public getLatestVersion(): string {
+  public getLatestVersion(): { version: string; title: string } {
     return this.latestVersion;
   }
 

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -14,7 +14,13 @@ export class AppService {
   private updateError: Record<string, (config: Config) => void>;
   private latestVersionAssetsURL: string;
   private version: string;
-  private latestVersion: string;
+  private latestVersion: {
+    version: string;
+    title: string;
+  } = {
+    version: '',
+    title: '',
+  };
 
   public updateAvailable = false;
   public dev = !!process.env.APP_DEV;
@@ -75,14 +81,14 @@ export class AppService {
 
     this.http.get('https://api.github.com/repos/UnchartedBull/OctoDash/releases/latest').subscribe({
       next: (data: GitHubReleaseInformation): void => {
-        this.latestVersion = data.tag_name.replace('v', '');
+        this.latestVersion = { version: data.tag_name.replace('v', ''), title: data.name };
         this.latestVersionAssetsURL = data.assets_url;
-        if (this.version != this.latestVersion) {
+        if (this.version != this.latestVersion.version) {
           if (!this.updateAvailable) {
             // Display notification first time that update is detected
             this.notificationService.setNotification({
               heading: $localize`:@@update-available:Update available!`,
-              text: $localize`:@@update-available-long:Version ${this.latestVersion} is available. Go to Settings > About to update.`,
+              text: $localize`:@@update-available-long:Version ${this.latestVersion.title} is available. Go to Settings > About to update.`,
               type: NotificationType.INFO,
               time: new Date(),
             });

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -736,7 +736,7 @@
             *ngIf="service.updateAvailable"
             (click)="showUpdate()"
             i18n="@@about-install-v">
-            install v{{ service.latestVersion }}
+            install v{{ service.latestVersion.title }}
           </button>
           <span class="settings__about-copyright">
             &#169; 2019-2024 UnchartedBull + various contributors<br />

--- a/src/locale/messages.de.xlf
+++ b/src/locale/messages.de.xlf
@@ -17,7 +17,7 @@
       </trans-unit>
       <trans-unit id="update-available-long" datatype="html">
         <source>Version 
-          <x id="PH" equiv-text="this.latestVersion"/> is available. Go to Settings &gt; About to update.
+          <x id="PH" equiv-text="this.latestVersion.title"/> is available. Go to Settings &gt; About to update.
         </source>
         <target></target>
       </trans-unit>
@@ -800,6 +800,7 @@
       </trans-unit>
       <trans-unit id="octoprint-upgrade-required-title" datatype="html">
         <source>OctoPrint outdated!</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="octoprint-upgrade-required-long" datatype="html">
         <source>OctoPrint must be running at least 
@@ -1202,7 +1203,7 @@
       </trans-unit>
       <trans-unit id="about-install-v" datatype="html">
         <source> install v
-          <x id="INTERPOLATION" equiv-text="{{ service.latestVersion }}"/>
+          <x id="INTERPOLATION" equiv-text="{{ service.latestVersion.title }}"/>
         </source>
         <target>installiere v</target>
       </trans-unit>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -19,7 +19,7 @@
       </trans-unit>
       <trans-unit id="update-available-long" datatype="html">
         <source>Version 
-          <x id="PH" equiv-text="this.latestVersion"/> is available. Go to Settings &gt; About to update.
+          <x id="PH" equiv-text="this.latestVersion.title"/> is available. Go to Settings &gt; About to update.
         </source>
         <target></target>
       </trans-unit>
@@ -802,6 +802,7 @@
       </trans-unit>
       <trans-unit id="octoprint-upgrade-required-title" datatype="html">
         <source>OctoPrint outdated!</source>
+        <target></target>
       </trans-unit>
       <trans-unit id="octoprint-upgrade-required-long" datatype="html">
         <source>OctoPrint must be running at least 
@@ -1209,7 +1210,7 @@
       </trans-unit>
       <trans-unit id="about-install-v" datatype="html">
         <source> install v
-          <x id="INTERPOLATION" equiv-text="{{ service.latestVersion }}"/>
+          <x id="INTERPOLATION" equiv-text="{{ service.latestVersion.title }}"/>
         </source>
         <target>installer v
           <x id="INTERPOLATION" equiv-text="{{ service.latestVersion }}"/>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -20,7 +20,7 @@
         <source>Update available!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.service.ts</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">90</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/settings/settings.component.html</context>
@@ -28,17 +28,17 @@
         </context-group>
       </trans-unit>
       <trans-unit id="update-available-long" datatype="html">
-        <source>Version <x id="PH" equiv-text="this.latestVersion"/> is available. Go to Settings &gt; About to update.</source>
+        <source>Version <x id="PH" equiv-text="this.latestVersion.title"/> is available. Go to Settings &gt; About to update.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.service.ts</context>
-          <context context-type="linenumber">85</context>
+          <context context-type="linenumber">91</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-load-style" datatype="html">
         <source>Can&apos;t load custom styles!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.service.ts</context>
-          <context context-type="linenumber">136</context>
+          <context context-type="linenumber">142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-enclosure-temp" datatype="html">
@@ -2052,7 +2052,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="about-install-v" datatype="html">
-        <source> install v<x id="INTERPOLATION" equiv-text="{{ service.latestVersion }}"/> </source>
+        <source> install v<x id="INTERPOLATION" equiv-text="{{ service.latestVersion.title }}"/> </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/settings/settings.component.html</context>
           <context context-type="linenumber">738,740</context>


### PR DESCRIPTION
In v2.4.0, the update checker logic was tweaked to use tag names.  This PR updates the logic to snag the release name again for display purposes.
