### PR TITLE
Improve update flow and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ No Keyboard? [No Problem](https://github.com/UnchartedBull/OctoDash/wiki/Setup-&
 
 Having issues during the installation? Please have a look at the [Troubleshooting Guide](https://github.com/UnchartedBull/OctoDash/wiki/Troubleshooting) first.
 
+## Update
+
+Updates can be made through the OctoDash UI, by clicking Settings > About > Install \[CurrentVersion\]!
+
+Updates can also be made via the command line:
+
+```
+bash <(wget -qO- https://github.com/UnchartedBull/OctoDash/raw/main/scripts/update.sh)
+```
+
 ## Tips and Tricks
 
 - OctoDash supports printing from your Raspberry and from the printers SD card, if configured in OctoPrint (v1.5.0 and up)

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -728,6 +728,7 @@
           <button
             class="settings__about-update settings__about-update-not-available"
             *ngIf="!(service.updateAvailable || service.dev)"
+            (click)="showUpdate()"
             i18n="@@about-no-update">
             up to date
           </button>

--- a/src/app/update/update.component.html
+++ b/src/app/update/update.component.html
@@ -24,14 +24,12 @@
   </div>
   <div *ngIf="page === 3">
     <span class="update-heading" i18n="@@update-confirmation">v{{ service.latestVersion }} installed</span>
-    <span class="update-restart" i18n="@@update-reboot"
-      >would you like to reboot now to activate the latest version?</span
-    >
+    <span class="update-restart" i18n="@@update-restart">would you like to restart OctoDash now?</span>
     <div class="update-restart-button__wrapper">
-      <button class="update-restart-button update-restart-button__no" (click)="closeUpdateWindow()" i18n="@@reboot-no">
+      <button class="update-restart-button update-restart-button__no" (click)="closeUpdateWindow()" i18n="@@restart-no">
         no
       </button>
-      <button class="update-restart-button update-restart-button__yes" (click)="reboot()" i18n="@@reboot-yes">
+      <button class="update-restart-button update-restart-button__yes" (click)="restart()" i18n="@@restart-yes">
         yes
       </button>
     </div>

--- a/src/app/update/update.component.ts
+++ b/src/app/update/update.component.ts
@@ -90,7 +90,7 @@ export class UpdateComponent implements OnInit {
     });
   }
 
-  public reboot(): void {
-    this.systemService.sendCommand('reboot');
+  public restart(): void {
+    this.electronService.send('restart');
   }
 }

--- a/src/helper/listener.js
+++ b/src/helper/listener.js
@@ -3,7 +3,7 @@ import { exec } from 'node:child_process';
 import { checkConfig, readConfig, resetConfig, saveConfig } from './config.js';
 import { startDiscovery, stopDiscovery } from './discover.js';
 import sendCustomStyles from './styles.js';
-import { downloadUpdate, sendVersionInfo } from './update.js';
+import { downloadUpdate, sendVersionInfo, restartOctoDash } from './update.js';
 
 function activateScreenSleepListener(ipcMain) {
   ipcMain.on('screenControl', (_, screenCommand) => exec(screenCommand.command));
@@ -26,6 +26,10 @@ function activateUpdateListener(ipcMain, window) {
   ipcMain.on('update', (_, updateInfo) => downloadUpdate(updateInfo, window));
 }
 
+function activateRestartListener(ipcMain, app) {
+  ipcMain.on('restart', () => restartOctoDash(app));
+}
+
 function activateDiscoverListener(ipcMain, window) {
   ipcMain.on('discover', () => startDiscovery(window));
 
@@ -44,6 +48,7 @@ function activateListeners(ipcMain, window, app, url) {
   activateAppInfoListener(ipcMain, window, app);
   activateScreenSleepListener(ipcMain);
   activateReloadListener(ipcMain, window, url);
+  activateRestartListener(ipcMain, app);
   activateUpdateListener(ipcMain, window);
   activateDiscoverListener(ipcMain, window);
 }

--- a/src/helper/listener.js
+++ b/src/helper/listener.js
@@ -3,7 +3,7 @@ import { exec } from 'node:child_process';
 import { checkConfig, readConfig, resetConfig, saveConfig } from './config.js';
 import { startDiscovery, stopDiscovery } from './discover.js';
 import sendCustomStyles from './styles.js';
-import { downloadUpdate, sendVersionInfo, restartOctoDash } from './update.js';
+import { downloadUpdate, restartOctoDash, sendVersionInfo } from './update.js';
 
 function activateScreenSleepListener(ipcMain) {
   ipcMain.on('screenControl', (_, screenCommand) => exec(screenCommand.command));

--- a/src/helper/update.js
+++ b/src/helper/update.js
@@ -101,3 +101,8 @@ export function sendVersionInfo(window, app) {
     version: app.getVersion(),
   });
 }
+
+export function restartOctoDash(app) {
+  app.relaunch();
+  app.exit();
+}

--- a/src/locale/messages.de.xlf
+++ b/src/locale/messages.de.xlf
@@ -1309,17 +1309,14 @@
         </source>
         <target>v installieret</target>
       </trans-unit>
-      <trans-unit id="update-reboot" datatype="html">
-        <source>would you like to reboot now to activate the latest version?</source>
-        <target>willst du einen Neustart ausführen um die neuste Version zu nutzen?</target>
+      <trans-unit id="update-restart" datatype="html">
+        <source>would you like to restart OctoDash now?</source>
       </trans-unit>
-      <trans-unit id="reboot-no" datatype="html">
+      <trans-unit id="restart-no" datatype="html">
         <source> no </source>
-        <target>nein</target>
       </trans-unit>
-      <trans-unit id="reboot-yes" datatype="html">
+      <trans-unit id="restart-yes" datatype="html">
         <source> yes </source>
-        <target>ja</target>
       </trans-unit>
       <trans-unit id="error-update" datatype="html">
         <source>Can't initiate update!</source>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -1320,17 +1320,14 @@
           <x id="INTERPOLATION" equiv-text="{{ service.latestVersion }}"/> installée
         </target>
       </trans-unit>
-      <trans-unit id="update-reboot" datatype="html">
-        <source>would you like to reboot now to activate the latest version?</source>
-        <target>Souhaitez-vous redémarrer maintenant pour activer la dernière version ?</target>
+      <trans-unit id="update-restart" datatype="html">
+        <source>would you like to restart OctoDash now?</source>
       </trans-unit>
-      <trans-unit id="reboot-no" datatype="html">
+      <trans-unit id="restart-no" datatype="html">
         <source> no </source>
-        <target>non</target>
       </trans-unit>
-      <trans-unit id="reboot-yes" datatype="html">
+      <trans-unit id="restart-yes" datatype="html">
         <source> yes </source>
-        <target>oui</target>
       </trans-unit>
       <trans-unit id="error-update" datatype="html">
         <source>Can't initiate update!</source>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -2048,49 +2048,49 @@
         <source> up to date </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/settings/settings.component.html</context>
-          <context context-type="linenumber">731,733</context>
+          <context context-type="linenumber">732,734</context>
         </context-group>
       </trans-unit>
       <trans-unit id="about-install-v" datatype="html">
         <source> install v<x id="INTERPOLATION" equiv-text="{{ service.latestVersion.title }}"/> </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/settings/settings.component.html</context>
-          <context context-type="linenumber">738,740</context>
+          <context context-type="linenumber">739,741</context>
         </context-group>
       </trans-unit>
       <trans-unit id="connection" datatype="html">
         <source>Connection</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/settings/settings.component.html</context>
-          <context context-type="linenumber">745</context>
+          <context context-type="linenumber">746</context>
         </context-group>
       </trans-unit>
       <trans-unit id="licence" datatype="html">
         <source>License</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/settings/settings.component.html</context>
-          <context context-type="linenumber">749</context>
+          <context context-type="linenumber">750</context>
         </context-group>
       </trans-unit>
       <trans-unit id="special-thanks" datatype="html">
         <source>Special Thanks</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/settings/settings.component.html</context>
-          <context context-type="linenumber">790</context>
+          <context context-type="linenumber">791</context>
         </context-group>
       </trans-unit>
       <trans-unit id="special-thanks-message" datatype="html">
         <source> Special Thanks to /u/Slateclean for supplying touchscreens, so development can continue! </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/settings/settings.component.html</context>
-          <context context-type="linenumber">791,793</context>
+          <context context-type="linenumber">792,794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="reset-config" datatype="html">
         <source>Reset Config</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/settings/settings.component.html</context>
-          <context context-type="linenumber">797</context>
+          <context context-type="linenumber">798</context>
         </context-group>
       </trans-unit>
       <trans-unit id="top-left" datatype="html">
@@ -2233,25 +2233,25 @@
           <context context-type="linenumber">26</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="update-reboot" datatype="html">
-        <source>would you like to reboot now to activate the latest version?</source>
+      <trans-unit id="update-restart" datatype="html">
+        <source>would you like to restart OctoDash now?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/update/update.component.html</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">27</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="reboot-no" datatype="html">
+      <trans-unit id="restart-no" datatype="html">
         <source> no </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/update/update.component.html</context>
-          <context context-type="linenumber">31,33</context>
+          <context context-type="linenumber">29,31</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="reboot-yes" datatype="html">
+      <trans-unit id="restart-yes" datatype="html">
         <source> yes </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/update/update.component.html</context>
-          <context context-type="linenumber">34,36</context>
+          <context context-type="linenumber">32,34</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-update" datatype="html">


### PR DESCRIPTION
This PR performs a few updates to the update procedure and documentation:

- Adds a section about updating to the readme (fixes #4860)
- Restarts _OctoDash,_ not OctoPrint's host system, after updates (fixes #4856)
- Allows a user to update OctoDash even if no update is available
