### PR TITLE
Fix config for < 6 custom actions

### DIFF
--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -51,6 +51,16 @@ export class SettingsComponent implements OnInit, OnDestroy {
   }
 
   public ngOnInit(): void {
+    const currentCommands = this.config.octodash.customActions.length;
+    for (let i = currentCommands; i < 6; i++) {
+      this.config.octodash.customActions.push({
+        icon: 'mdi mdi-plus',
+        command: '',
+        color: '#ffffff',
+        confirm: false,
+        exit: false,
+      });
+    }
     setTimeout((): void => {
       this.pages = [
         this.settingsMain.nativeElement,

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -2139,21 +2139,21 @@
         <source>Configuration not saved!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/settings/settings.component.ts</context>
-          <context context-type="linenumber">82</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="conf-unsaved-message" datatype="html">
         <source>You haven&apos;t saved your config yet, so your changes will not be applied. Click close again if you want to discard your changes!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/settings/settings.component.ts</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-invalid-config" datatype="html">
         <source>Can&apos;t save invalid config</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/settings/settings.component.ts</context>
-          <context context-type="linenumber">119</context>
+          <context context-type="linenumber">129</context>
         </context-group>
       </trans-unit>
       <trans-unit id="octoprint-sleeping" datatype="html">


### PR DESCRIPTION
This allows the config screen to load with fewer than six custom actions configured. While the UI doesn't allow for getting into that state, the companion plugin does (plus of course directly modifying the config is possible).

Fixes #4836 