### PR TITLE
Fix scrolling of Action Center (properly)

### DIFF
--- a/src/components/action-center/action-center.component.html
+++ b/src/components/action-center/action-center.component.html
@@ -15,7 +15,8 @@
         (onLongPress)="editing = i"
         matRipple
         [matRippleUnbounded]="false"
-        cdkDrag>
+        cdkDrag
+        [cdkDragStartDelay]="300">
         <fa-icon
           [icon]="customAction.icon"
           class="custom-actions__action-icon"

--- a/src/components/action-center/action-center.component.scss
+++ b/src/components/action-center/action-center.component.scss
@@ -5,7 +5,7 @@
   bottom: 0;
   transform: translateY(100%);
   width: 100vw;
-  height: 14vw;
+  height: 12vw;
   z-index: 10;
   background: linear-gradient(to bottom, rgb(0 0 0 / 45%), rgb(0 0 0 / 80%));
   mask-image: linear-gradient(to bottom, transparent 0%, white 10%);
@@ -20,6 +20,10 @@
     width: 96vw;
     padding: 0 2vw;
     overflow-x: scroll;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
   }
 
   &__action-list {


### PR DESCRIPTION
This PR performs a more proper fix of the Action Center scrolling issue, allowing the center to be scrolled whilst tapping on the icons.  Actions must now be pressed and held for a short moment before they can be drag-and-drop rearranged.

This also gets rid of the scrollbar, which ended up preventing scrolling when tapping on it anyways.
