### PR TITLE
URI Encode filepaths in API calls

### DIFF
--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -1956,21 +1956,21 @@
         <source>Can&apos;t load file!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/services/files/files.octoprint.service.ts</context>
-          <context context-type="linenumber">160</context>
+          <context context-type="linenumber">168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="files-error-print" datatype="html">
         <source>Can&apos;t start print!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/services/files/files.octoprint.service.ts</context>
-          <context context-type="linenumber">177</context>
+          <context context-type="linenumber">189</context>
         </context-group>
       </trans-unit>
       <trans-unit id="files-error-delete" datatype="html">
         <source>Can&apos;t delete file!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/services/files/files.octoprint.service.ts</context>
-          <context context-type="linenumber">189</context>
+          <context context-type="linenumber">201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-start-job" datatype="html">

--- a/src/services/files/files.octoprint.service.ts
+++ b/src/services/files/files.octoprint.service.ts
@@ -117,34 +117,38 @@ export class FilesOctoprintService implements FilesService {
   }
 
   public getFile(filePath: string): Observable<File> {
-    return this.http.get(this.configService.getApiURL('files' + filePath), this.configService.getHTTPHeaders()).pipe(
-      map((file: OctoprintFile): File => {
-        return {
-          origin: file.origin,
-          path: '/' + file.origin + '/' + file.path,
-          name: file.name,
-          date: this.conversionService.convertDateToString(new Date(file.date * 1000)),
-          size: this.conversionService.convertByteToMegabyte(file.size),
-          thumbnail: file.thumbnail ? this.configService.getApiURL(file.thumbnail, false) : 'assets/object.svg',
-          ...(file.gcodeAnalysis
-            ? {
-                printTime: this.conversionService.convertSecondsToHours(file.gcodeAnalysis.estimatedPrintTime),
-                filamentWeight: this.conversionService.convertFilamentLengthToWeight(
-                  _.sumBy(_.values(file.gcodeAnalysis.filament), tool => tool.length),
-                ),
-              }
-            : {}),
-        } as File;
-      }),
-    );
+    return this.http
+      .get(this.configService.getApiURL('files' + encodeURIComponent(filePath)), this.configService.getHTTPHeaders())
+      .pipe(
+        map((file: OctoprintFile): File => {
+          return {
+            origin: file.origin,
+            path: '/' + file.origin + '/' + file.path,
+            name: file.name,
+            date: this.conversionService.convertDateToString(new Date(file.date * 1000)),
+            size: this.conversionService.convertByteToMegabyte(file.size),
+            thumbnail: file.thumbnail ? this.configService.getApiURL(file.thumbnail, false) : 'assets/object.svg',
+            ...(file.gcodeAnalysis
+              ? {
+                  printTime: this.conversionService.convertSecondsToHours(file.gcodeAnalysis.estimatedPrintTime),
+                  filamentWeight: this.conversionService.convertFilamentLengthToWeight(
+                    _.sumBy(_.values(file.gcodeAnalysis.filament), tool => tool.length),
+                  ),
+                }
+              : {}),
+          } as File;
+        }),
+      );
   }
 
   public getThumbnail(filePath: string): Observable<string> {
-    return this.http.get(this.configService.getApiURL('files' + filePath), this.configService.getHTTPHeaders()).pipe(
-      map((file: OctoprintFile): string => {
-        return file.thumbnail ? this.configService.getApiURL(file.thumbnail, false) : 'assets/object.svg';
-      }),
-    );
+    return this.http
+      .get(this.configService.getApiURL('files' + encodeURIComponent(filePath)), this.configService.getHTTPHeaders())
+      .pipe(
+        map((file: OctoprintFile): string => {
+          return file.thumbnail ? this.configService.getApiURL(file.thumbnail, false) : 'assets/object.svg';
+        }),
+      );
   }
 
   public loadFile(filePath: string): void {
@@ -154,7 +158,11 @@ export class FilesOctoprintService implements FilesService {
     };
 
     this.http
-      .post(this.configService.getApiURL('files' + filePath), payload, this.configService.getHTTPHeaders())
+      .post(
+        this.configService.getApiURL('files' + encodeURIComponent(filePath)),
+        payload,
+        this.configService.getHTTPHeaders(),
+      )
       .pipe(
         catchError(error => {
           this.notificationService.error($localize`:@@files-error-file:Can't load file!`, error.message);
@@ -171,7 +179,11 @@ export class FilesOctoprintService implements FilesService {
     };
 
     this.http
-      .post(this.configService.getApiURL('files' + filePath), payload, this.configService.getHTTPHeaders())
+      .post(
+        this.configService.getApiURL('files' + encodeURIComponent(filePath)),
+        payload,
+        this.configService.getHTTPHeaders(),
+      )
       .pipe(
         catchError(error => {
           this.notificationService.error($localize`:@@files-error-print:Can't start print!`, error.message);
@@ -183,7 +195,7 @@ export class FilesOctoprintService implements FilesService {
 
   public deleteFile(filePath: string): void {
     this.http
-      .delete(this.configService.getApiURL('files' + filePath), this.configService.getHTTPHeaders())
+      .delete(this.configService.getApiURL('files' + encodeURIComponent(filePath)), this.configService.getHTTPHeaders())
       .pipe(
         catchError(error => {
           this.notificationService.error($localize`:@@files-error-delete:Can't delete file!`, error.message);


### PR DESCRIPTION
Print files with `#`, `-` and other characters were causing related API calls to fail, preventing such files from being viewed or started from OctoDash. This change adds URI encoding to those filenames when including in API calls to fix the issues.