### PR TITLE
Send gcode from custom actions in batches

### DIFF
--- a/src/components/action-center/action-center.component.ts
+++ b/src/components/action-center/action-center.component.ts
@@ -119,15 +119,22 @@ export class ActionCenterComponent implements OnInit, OnDestroy {
         exit,
       };
     } else {
-      const parsed = this.parseCommand(command);
-      parsed.specials.forEach(action => {
-        this.executeSpecialCommand(action);
-      });
-      this.executeGCode(parsed.gcodes.join(';'));
-      if (exit) {
-        this.router.navigate(['/main-screen']);
+      try {
+        const parsed = this.parseCommand(command);
+        parsed.specials.forEach(action => {
+          this.executeSpecialCommand(action);
+        });
+        this.executeGCode(parsed.gcodes.join(';'));
+        if (exit) {
+          this.router.navigate(['/main-screen']);
+        }
+        this.hideConfirm();
+      } catch {
+        this.notificationService.error(
+          $localize`:@@error-parsing-custom-action:Error parsing custom action!`,
+          $localize`:@@error-parsing-custom-action-desc:Unable to parse the custom action.`,
+        );
       }
-      this.hideConfirm();
     }
   }
 

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -45,6 +45,12 @@
         <source>close</source>
         <target>luk</target>
       </trans-unit>
+      <trans-unit id="error-parsing-custom-action" datatype="html">
+        <source>Error parsing custom action!</source>
+      </trans-unit>
+      <trans-unit id="error-parsing-custom-action-desc" datatype="html">
+        <source>Unable to parse the custom action.</source>
+      </trans-unit>
       <trans-unit id="error-custom-action-invalid" datatype="html">
         <source>Unknown special command!</source>
         <target>Ukendt specialkommando!</target>

--- a/src/locale/messages.de.xlf
+++ b/src/locale/messages.de.xlf
@@ -45,6 +45,12 @@
         <source>close</source>
         <target>schließen</target>
       </trans-unit>
+      <trans-unit id="error-parsing-custom-action" datatype="html">
+        <source>Error parsing custom action!</source>
+      </trans-unit>
+      <trans-unit id="error-parsing-custom-action-desc" datatype="html">
+        <source>Unable to parse the custom action.</source>
+      </trans-unit>
       <trans-unit id="error-custom-action-invalid" datatype="html">
         <source>Unknown special command!</source>
         <target>Unbekannter Spezialbefehl!</target>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -45,6 +45,12 @@
         <source>close</source>
         <target>fermer</target>
       </trans-unit>
+      <trans-unit id="error-parsing-custom-action" datatype="html">
+        <source>Error parsing custom action!</source>
+      </trans-unit>
+      <trans-unit id="error-parsing-custom-action-desc" datatype="html">
+        <source>Unable to parse the custom action.</source>
+      </trans-unit>
       <trans-unit id="error-custom-action-invalid" datatype="html">
         <source>Unknown special command!</source>
         <target>Commande spéciale inconnue !</target>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -79,32 +79,46 @@
           <context context-type="linenumber">134,140</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="error-parsing-custom-action" datatype="html">
+        <source>Error parsing custom action!</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
+          <context context-type="linenumber">134</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="error-parsing-custom-action-desc" datatype="html">
+        <source>Unable to parse the custom action.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
+          <context context-type="linenumber">135</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="error-custom-action-invalid" datatype="html">
         <source>Unknown special command!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
-          <context context-type="linenumber">151</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-custom-action-invalid-desc" datatype="html">
         <source>The special command you have entered is unknown.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
-          <context context-type="linenumber">152</context>
+          <context context-type="linenumber">159</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-custom-action-disabled" datatype="html">
         <source>Printer commands are not available!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
-          <context context-type="linenumber">164</context>
+          <context context-type="linenumber">171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-custom-action-disabled-desc" datatype="html">
         <source>Please connect to your printer first before attempting to use a printer command.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
-          <context context-type="linenumber">165</context>
+          <context context-type="linenumber">172</context>
         </context-group>
       </trans-unit>
       <trans-unit id="long-init" datatype="html">

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -83,28 +83,28 @@
         <source>Unknown special command!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
-          <context context-type="linenumber">141</context>
+          <context context-type="linenumber">151</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-custom-action-invalid-desc" datatype="html">
         <source>The special command you have entered is unknown.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
-          <context context-type="linenumber">142</context>
+          <context context-type="linenumber">152</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-custom-action-disabled" datatype="html">
         <source>Printer commands are not available!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
-          <context context-type="linenumber">153</context>
+          <context context-type="linenumber">164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-custom-action-disabled-desc" datatype="html">
         <source>Please connect to your printer first before attempting to use a printer command.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
-          <context context-type="linenumber">154</context>
+          <context context-type="linenumber">165</context>
         </context-group>
       </trans-unit>
       <trans-unit id="long-init" datatype="html">

--- a/src/services/printer/printer.octoprint.service.ts
+++ b/src/services/printer/printer.octoprint.service.ts
@@ -71,7 +71,7 @@ export class PrinterOctoprintService implements PrinterService {
 
   public executeGCode(gCode: string): void {
     const gCodePayload: GCodeCommand = {
-      commands: gCode.split('; '),
+      commands: gCode.split(';'),
     };
     this.http
       .post(this.configService.getApiURL('printer/command'), gCodePayload, this.configService.getHTTPHeaders())


### PR DESCRIPTION
Fixes #4289

Each custom action can contain multiple commands, separated by `;`. When multiple gcode commands are present, each is sent as a separate API call to OctoPrint. This can result in OctoPrint processing those commands out of order. 

This change remedies that by sending all gcode in a custom action as a single request to OctoPrint, guaranteeing that those will be executed in order. This change also processes any special commands before sending the gcode, although I expect that will not cause any significant issues as commands are always dispatched without waiting for results, so the exact order of execution has always been undefined and variable.