### PR TITLE
Dependabot: update Angular all together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     open-pull-requests-limit: 15
     labels:
       - dependencies
+    groups:
+      angular:
+        applies-to: version-updates
+        patterns:
+          - '@angular*'


### PR DESCRIPTION
This PR ensures that Dependabot will update all of the Angular packages together, rather than attempting to update them individually and failing (or worse, succeeding on some).
