### PR TITLE
Disable automerge of dependabot PRs

### DIFF
--- a/.github/workflows/approve-and-merge-dependency-updates.yaml
+++ b/.github/workflows/approve-and-merge-dependency-updates.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Auto Approve
         uses: hmarr/auto-approve-action@v4
-        if: github.actor == 'dependabot[bot]'
+        if: false && github.actor == 'dependabot[bot]'
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
   auto-merge:


### PR DESCRIPTION
The process of cutting a release branch, doing prerelease builds, and then deploying the release gets complicated when `main` is getting updated under the hood automatically