### PR TITLE
Fix changelog for 2.6.0 and 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,19 @@
 # Changelog
 
-## [v2.6.1](https://github.com/UnchartedBull/OctoDash/tree/v2.5.4) (2025-09-03)
+## [v2.6.1](https://github.com/UnchartedBull/OctoDash/tree/v2.6.1) (2025-09-04)
 
 > [!IMPORTANT]
-> OctoDash v2.5.4 requires OctoPrint v1.9.0 or higher.
+> OctoDash v2.6.1 requires OctoPrint v1.9.0 or higher.
 
 > [!WARNING]
 > If you use custom styles, you may need to update them.
 
 This version corrects some packaging issues with 2.6.0
 
-## [v2.6.0](https://github.com/UnchartedBull/OctoDash/tree/v2.5.4) (2025-09-03)
+## [v2.6.0](https://github.com/UnchartedBull/OctoDash/tree/v2.6.0) (2025-09-03)
 
 > [!IMPORTANT]
-> OctoDash v2.5.4 requires OctoPrint v1.9.0 or higher.
+> OctoDash v2.6.0 requires OctoPrint v1.9.0 or higher.
 
 > [!WARNING]
 > If you use custom styles, you may need to update them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## [v2.5.4](https://github.com/UnchartedBull/OctoDash/tree/v2.5.4) (2025-09-03)
+## [v2.6.1](https://github.com/UnchartedBull/OctoDash/tree/v2.5.4) (2025-09-03)
+
+> [!IMPORTANT]
+> OctoDash v2.5.4 requires OctoPrint v1.9.0 or higher.
+
+> [!WARNING]
+> If you use custom styles, you may need to update them.
+
+This version corrects some packaging issues with 2.6.0
+
+## [v2.6.0](https://github.com/UnchartedBull/OctoDash/tree/v2.5.4) (2025-09-03)
 
 > [!IMPORTANT]
 > OctoDash v2.5.4 requires OctoPrint v1.9.0 or higher.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "octodash",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "octodash",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "Apache 2.0",
       "dependencies": {
         "@angular/animations": "^20.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "octodash",
   "description": "OctoDash is a simple, but beautiful dashboard for Octoprint.",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "license": "Apache 2.0",
   "homepage": "https://github.com/UnchartedBull/OctoDash",
   "author": {


### PR DESCRIPTION
2.6.1 didn't get included, and 2.6.0 was still named 2.5.4