### PR TITLE
Don't include `.yaml` in release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,7 +82,6 @@ jobs:
           name: build
           path: |
             package/*.deb
-            package/*.yaml
             package/*.yml
 
   release:
@@ -98,4 +97,4 @@ jobs:
       - name: Upload release
         env:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        run: gh release upload ${{ github.ref }} *.deb *.yaml *.yml
+        run: gh release upload ${{ github.ref }} *.deb *.yml


### PR DESCRIPTION
Seems only `.yml` are produced. Also skips saving those in the GHA artifact for good measure