### PR TITLE
Allow Changing OctoPrint instance

### DIFF
--- a/octoprint_octodash/__init__.py
+++ b/octoprint_octodash/__init__.py
@@ -45,7 +45,7 @@ class OctodashPlugin(
         self.use_received_fan_speeds = False
         self.fan_regex = re.compile("M106 (?:P([0-9]) )?S([0-9]+)")
         self.fan_regex_m107 = re.compile("M107(?: +P([0-9]+))?")
-        self.change_instance = re.compile(r'^chromium-browser.*(http.*?)(?: |$)', re.MULTILINE)
+        self.change_instance = re.compile(r'^OCTOPRINT_URL=(http.*?)(?: |$)', re.MULTILINE)
 
     ##~~ SettingsPlugin mixin
 
@@ -569,18 +569,21 @@ class OctodashPlugin(
         return [{"path": p, "exists":  os.path.exists(p)} for p in expanded]
 
     def _update_xinit_for_instance(self, xinit, path):
-        match = re.match(self.change_instance, xinit)
+        match = self.change_instance.search(xinit)
         new = xinit.replace(match.group(1), path)
 
         return new
 
     def _change_boot_instance(self, instance):
         self._logger.info("Changing boot instance to {}".format(instance))
-        with open("~/.xinitrc", "w") as f:
+        fullpath = os.path.expanduser('~/.xinitrc')
+        self._logger.debug("Full path to xinit: {}".format(fullpath))
+        with open(fullpath, "r+") as f:
             xinit = f.read()
             self._logger.debug("Current xinit: {}".format(xinit))
             new_xinit = self._update_xinit_for_instance(xinit, instance)
             self._logger.debug("New xinit: {}".format(new_xinit))
+            f.seek(0)
             f.write(new_xinit)
 
     def _migrate_legacy_config(self, path):

--- a/octoprint_octodash/__init__.py
+++ b/octoprint_octodash/__init__.py
@@ -45,6 +45,7 @@ class OctodashPlugin(
         self.use_received_fan_speeds = False
         self.fan_regex = re.compile("M106 (?:P([0-9]) )?S([0-9]+)")
         self.fan_regex_m107 = re.compile("M107(?: +P([0-9]+))?")
+        self.change_instance = re.compile(r'^chromium-browser.*(http.*?)(?: |$)', re.MULTILINE)
 
     ##~~ SettingsPlugin mixin
 
@@ -377,6 +378,23 @@ class OctodashPlugin(
 
         return make_response(json.dumps({"success": True}), 200)
 
+    @Permissions.ADMIN.require(403)
+    @octoprint.plugin.BlueprintPlugin.route("/api/change_instances", methods=["POST"])
+    def change_instance_route(self):
+        data = request.json
+        if not data or "instance" not in data:
+            return make_response(json.dumps({"error": "Instance not provided"}), 400)
+        
+        try:
+            instance = data["instance"]
+            self._change_boot_instance(instance)
+            response = make_response(json.dumps({"success": True}), 200)
+        except Exception as e:
+            self._logger.error(f"Error changing boot instance: {e}")
+            response = make_response(json.dumps({"error": "Error changing boot instance"}), 500)
+
+        return response
+
     @Permissions.WEBCAM.require(403)
     @octoprint.plugin.BlueprintPlugin.route("webcam")
     def webcam_route(self):
@@ -549,7 +567,20 @@ class OctodashPlugin(
 
         return [{"path": p, "exists":  os.path.exists(p)} for p in expanded]
 
+    def _update_xinit_for_instance(self, xinit, path):
+        match = re.match(self.change_instance, xinit)
+        new = xinit.replace(match.group(1), path)
 
+        return new
+
+    def _change_boot_instance(self, instance):
+        self._logger.info("Changing boot instance to {}".format(instance))
+        with open("~/.xinitrc", "w") as f:
+            xinit = f.read()
+            self._logger.debug("Current xinit: {}".format(xinit))
+            new_xinit = self._update_xinit_for_instance(xinit, instance)
+            self._logger.debug("New xinit: {}".format(new_xinit))
+            f.write(new_xinit)
 
     def _migrate_legacy_config(self, path):
         with open(path, 'r') as f:

--- a/octoprint_octodash/__init__.py
+++ b/octoprint_octodash/__init__.py
@@ -65,7 +65,8 @@ class OctodashPlugin(
 
     def on_settings_save(self, data):
         for plugin_name in ALL_PLUGINS.keys():
-            del data["plugins"][plugin_name]['inUse']
+            if "plugins" in data:
+                del data["plugins"][plugin_name]['inUse']
 
         return super().on_settings_save(data)
 
@@ -379,7 +380,7 @@ class OctodashPlugin(
         return make_response(json.dumps({"success": True}), 200)
 
     @Permissions.ADMIN.require(403)
-    @octoprint.plugin.BlueprintPlugin.route("/api/change_instances", methods=["POST"])
+    @octoprint.plugin.BlueprintPlugin.route("/api/change_instance", methods=["POST"])
     def change_instance_route(self):
         data = request.json
         if not data or "instance" not in data:

--- a/octoprint_octodash/__init__.py
+++ b/octoprint_octodash/__init__.py
@@ -392,7 +392,7 @@ class OctodashPlugin(
         Expects a JSON body with the following format:
         {
             "instance": "http://new.instance.url", # leading and trailing whitespace will be stripped
-            "restart": true # optional, defaults to false
+            "restart": false # optional, defaults to true
         }
         """
         data = request.json
@@ -409,7 +409,7 @@ class OctodashPlugin(
             response = make_response(json.dumps({"error": "Error changing boot instance"}), 500)
             return response
 
-        if not data.get("restart", False):
+        if not data.get("restart", True):
             return response
 
         try:

--- a/octoprint_octodash/__init__.py
+++ b/octoprint_octodash/__init__.py
@@ -409,7 +409,9 @@ class OctodashPlugin(
             response = make_response(json.dumps({"error": "Error changing boot instance"}), 500)
             return response
 
-        if not data.get("restart", True):
+        should_restart = data.get("restart", True)
+        if not should_restart:
+            self._logger.info("Not restarting OctoDash on instance change per request")
             return response
 
         try:

--- a/octoprint_octodash/__init__.py
+++ b/octoprint_octodash/__init__.py
@@ -393,6 +393,7 @@ class OctodashPlugin(
         except Exception as e:
             self._logger.error(f"Error changing boot instance: {e}")
             response = make_response(json.dumps({"error": "Error changing boot instance"}), 500)
+            return response
 
         if not data.get("restart", False):
             return response

--- a/octoprint_octodash/__init__.py
+++ b/octoprint_octodash/__init__.py
@@ -382,13 +382,27 @@ class OctodashPlugin(
     @Permissions.ADMIN.require(403)
     @octoprint.plugin.BlueprintPlugin.route("/api/change_instance", methods=["POST"])
     def change_instance_route(self):
+        """
+        Change the boot instance.
+
+        Updates the user's bashrc to set the OCTOPRINT_URL to the provided instance.
+        If `restart` is true, will also attempt to restart OctoDash using the system
+        actions defined in the settings overlay.
+
+        Expects a JSON body with the following format:
+        {
+            "instance": "http://new.instance.url", # leading and trailing whitespace will be stripped
+            "restart": true # optional, defaults to false
+        }
+        """
         data = request.json
         if not data or "instance" not in data:
             return make_response(json.dumps({"error": "Instance not provided"}), 400)
         
         try:
-            instance = data["instance"]
-            self._change_boot_instance(instance)
+            instance: str = data["instance"]
+            trimmed = instance.strip()
+            self._change_boot_instance(trimmed)
             response = make_response(json.dumps({"success": True}), 200)
         except Exception as e:
             self._logger.error(f"Error changing boot instance: {e}")

--- a/octoprint_octodash/__init__.py
+++ b/octoprint_octodash/__init__.py
@@ -394,6 +394,27 @@ class OctodashPlugin(
             self._logger.error(f"Error changing boot instance: {e}")
             response = make_response(json.dumps({"error": "Error changing boot instance"}), 500)
 
+        if not data.get("restart", False):
+            return response
+
+        try:
+            # get restart command from settings
+            acitons = __plugin_settings_overlay__["system"]["actions"]
+            restart_action = next((a for a in acitons if a["action"] == "octodash_restart"))
+            command = restart_action["command"]
+            self._logger.info(f"Running restart command: {command}")
+            subprocess.run(command, shell=True, check=True, timeout=10)
+        except subprocess.TimeoutExpired:
+            self._logger.error("OctoDash restart command timed out")
+            response = make_response(json.dumps({"error": "Error restarting"}), 500)
+        except subprocess.CalledProcessError as e:
+            self._logger.error(f"Error restarting OctoDash: {e}")
+            response = make_response(json.dumps({"error": "Error restarting OctoDash"})),
+        except StopIteration:
+            self._logger.error("OctoDash restart command not found in settings overlay")
+            response = make_response(json.dumps({"error": "Unable to find restart command"}), 500)
+
+
         return response
 
     @Permissions.WEBCAM.require(403)

--- a/octoprint_octodash/__init__.py
+++ b/octoprint_octodash/__init__.py
@@ -45,7 +45,7 @@ class OctodashPlugin(
         self.use_received_fan_speeds = False
         self.fan_regex = re.compile("M106 (?:P([0-9]) )?S([0-9]+)")
         self.fan_regex_m107 = re.compile("M107(?: +P([0-9]+))?")
-        self.change_instance = re.compile(r'^\s*OCTOPRINT_URL=(http.*?)(?: |$)', re.MULTILINE)
+        self.change_instance = re.compile(r'^\s*export OCTOPRINT_URL=(http.*?)(?: |$)', re.MULTILINE)
 
     ##~~ SettingsPlugin mixin
 

--- a/octoprint_octodash/__init__.py
+++ b/octoprint_octodash/__init__.py
@@ -606,6 +606,7 @@ class OctodashPlugin(
             self._logger.debug("New bashrc: {}".format(new_script))
             f.seek(0)
             f.write(new_script)
+            f.truncate()
 
     def _migrate_legacy_config(self, path):
         with open(path, 'r') as f:

--- a/octoprint_octodash/__init__.py
+++ b/octoprint_octodash/__init__.py
@@ -398,9 +398,8 @@ class OctodashPlugin(
             return response
 
         try:
-            # get restart command from settings
-            acitons = __plugin_settings_overlay__["system"]["actions"]
-            restart_action = next((a for a in acitons if a["action"] == "octodash_restart"))
+            actions = self._settings.global_get(["system", "actions"])
+            restart_action = next((a for a in actions if a["action"] == "octodash_restart"))
             command = restart_action["command"]
             self._logger.info(f"Running restart command: {command}")
             subprocess.run(command, shell=True, check=True, timeout=10)

--- a/octoprint_octodash/__init__.py
+++ b/octoprint_octodash/__init__.py
@@ -45,7 +45,7 @@ class OctodashPlugin(
         self.use_received_fan_speeds = False
         self.fan_regex = re.compile("M106 (?:P([0-9]) )?S([0-9]+)")
         self.fan_regex_m107 = re.compile("M107(?: +P([0-9]+))?")
-        self.change_instance = re.compile(r'^OCTOPRINT_URL=(http.*?)(?: |$)', re.MULTILINE)
+        self.change_instance = re.compile(r'^\s*OCTOPRINT_URL=(http.*?)(?: |$)', re.MULTILINE)
 
     ##~~ SettingsPlugin mixin
 
@@ -576,7 +576,7 @@ class OctodashPlugin(
 
     def _change_boot_instance(self, instance):
         self._logger.info("Changing boot instance to {}".format(instance))
-        fullpath = os.path.expanduser('~/.xinitrc')
+        fullpath = os.path.expanduser('~/.bashrc')
         self._logger.debug("Full path to xinit: {}".format(fullpath))
         with open(fullpath, "r+") as f:
             xinit = f.read()

--- a/octoprint_octodash/__init__.py
+++ b/octoprint_octodash/__init__.py
@@ -577,14 +577,14 @@ class OctodashPlugin(
     def _change_boot_instance(self, instance):
         self._logger.info("Changing boot instance to {}".format(instance))
         fullpath = os.path.expanduser('~/.bashrc')
-        self._logger.debug("Full path to xinit: {}".format(fullpath))
+        self._logger.debug("Full path to bashrc: {}".format(fullpath))
         with open(fullpath, "r+") as f:
-            xinit = f.read()
-            self._logger.debug("Current xinit: {}".format(xinit))
-            new_xinit = self._update_xinit_for_instance(xinit, instance)
-            self._logger.debug("New xinit: {}".format(new_xinit))
+            script = f.read()
+            self._logger.debug("Current bashrc: {}".format(script))
+            new_script = self._update_xinit_for_instance(script, instance)
+            self._logger.debug("New bashrc: {}".format(new_script))
             f.seek(0)
-            f.write(new_xinit)
+            f.write(new_script)
 
     def _migrate_legacy_config(self, path):
         with open(path, 'r') as f:

--- a/octoprint_octodash/__init__.py
+++ b/octoprint_octodash/__init__.py
@@ -642,14 +642,14 @@ __plugin_name__ = "Octodash Plugin"
 # OctoPrint 1.8.0 onwards only supports Python 3.
 __plugin_pythoncompat__ = ">=3,<4"  # Only Python 3
 __plugin_settings_overlay__ = {'system': {'actions': [{'action': 'octodash_start',
-                                                        'command': 'sudo service getty@tty1 start',
+                                                        'command': 'sudo -n service getty@tty1 start',
                                                         'name': 'Start OctoDash'},
                                                         {'action': 'octodash_stop',
-                                                        'command': 'sudo service getty@tty1 stop',
+                                                        'command': 'sudo -n service getty@tty1 stop',
                                                         'name': 'Stop OctoDash',
                                                         'confirm': 'You are about to shutdown OctoDash.'},
                                                         {'action': 'octodash_restart',
-                                                        'command': 'sudo service getty@tty1 restart',
+                                                        'command': 'sudo -n service getty@tty1 restart',
                                                         'name': 'Restart OctoDash',
                                                         'confirm': 'You are about to restart OctoDash.'}]}}
 

--- a/octoprint_octodash/static/js/octodash.js
+++ b/octoprint_octodash/static/js/octodash.js
@@ -35,16 +35,6 @@ $(function () {
         //   data.confirm(true);
         //   data.exit(false);
         //   break;
-        // case '[!SWITCH_INSTANCE]':
-        //   data.command(
-        //     '[!WEB]' +
-        //       self.settingsViewModel.settings.plugins.octodashcompanion.config.octoprint.url().replace('/api/', '/') +
-        //       'plugin/octodashcompanion/switch_instance?url=localhost:5000',
-        //   );
-        //   data.icon('recycle');
-        //   data.color('#e1b12c');
-        //   data.exit(false);
-        //   break;
         default:
           data.command(event.currentTarget.text);
       }

--- a/octoprint_octodash/templates/octodash_settings.jinja2
+++ b/octoprint_octodash/templates/octodash_settings.jinja2
@@ -164,7 +164,7 @@ See https://github.com/jneilliii/OctoPrint-OctoDashCompanion/blob/142652a3c2eccf
                               <li><a href="#" data-bind="click: $root.addCustomActionToken">[!OUTPUT]identifier,status</a></li>
                               <li><a href="#" data-bind="click: $root.addCustomActionToken">[!OUTPUT_PWM]identifier,duty-cycle</a></li>
                               <li><a href="#" data-bind="click: $root.addCustomActionToken">[!ENC_SHELL]identifier</a></li>
-                              {# <li><a href="#" data-bind="click: $root.addCustomActionToken">[!SWITCH_INSTANCE]</a></li> #}
+                              <li><a href="#" data-bind="click: $root.addCustomActionToken">[!SWITCH_INSTANCE]path</a></li>
                             </ul>
                           </div>
                         </div>

--- a/src/components/action-center/action-center.component.ts
+++ b/src/components/action-center/action-center.component.ts
@@ -1,9 +1,9 @@
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { SafeResourceUrl } from '@angular/platform-browser';
-import { Router } from '@angular/router';
 import { Observable, Subscription } from 'rxjs';
 import { AppService } from 'src/services/app.service';
+import { ChangeInstanceService } from 'src/services/change-instance.service';
 
 import { CustomAction, PrinterState, PrinterStatus, PSUState } from '../../model';
 import { ConfigService } from '../../services/config.service';
@@ -24,6 +24,7 @@ const SpecialCommandRegex = /\[!([\w_]+)\]/;
 export class ActionCenterComponent implements OnInit, OnDestroy {
   @Input() closeEvent: Observable<void>;
   private eventsSubscription: Subscription;
+  private changeInstanceService = inject(ChangeInstanceService);
 
   public visible = false;
   public editing = -1;
@@ -46,6 +47,7 @@ export class ActionCenterComponent implements OnInit, OnDestroy {
     POWERON: () => this.enclosureService.setPSUState(PSUState.ON),
     POWERTOGGLE: () => this.enclosureService.togglePSU(),
     WEB: value => this.openIframe(value),
+    SWITCH_INSTANCE: value => this.changeInstance(value),
     WEBCAM: () => this.openIframe('/plugin/octodash/webcam'),
     NEOPIXEL: (...values) => this.setLEDColor(values[0], values[1], values[2], values[3]),
     OUTPUT: (...values) => this.setOutput(values[0], values[1]),
@@ -61,7 +63,6 @@ export class ActionCenterComponent implements OnInit, OnDestroy {
     private configService: ConfigService,
     private enclosureService: EnclosureService,
     private notificationService: NotificationService,
-    private router: Router,
   ) {
     this.customActions = this.configService.getCustomActions();
 
@@ -85,6 +86,17 @@ export class ActionCenterComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.eventsSubscription.unsubscribe();
+  }
+
+  private changeInstance(instance: string) {
+    this.changeInstanceService.changeInstance(instance).subscribe({
+      error: () => {
+        this.notificationService.error(
+          $localize`:@@error-change-instance:Failed to change instance!`,
+          $localize`:@@error-change-instance-desc:An error occurred while trying to change the OctoPrint instance.`,
+        );
+      },
+    });
   }
 
   public updateActionsInConfig() {

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -45,6 +45,12 @@
         <source>close</source>
         <target>luk</target>
       </trans-unit>
+      <trans-unit id="error-change-instance" datatype="html">
+        <source>Failed to change instance!</source>
+      </trans-unit>
+      <trans-unit id="error-change-instance-desc" datatype="html">
+        <source>An error occurred while trying to change the OctoPrint instance.</source>
+      </trans-unit>
       <trans-unit id="error-parsing-custom-action" datatype="html">
         <source>Error parsing custom action!</source>
         <target></target>

--- a/src/locale/messages.de.xlf
+++ b/src/locale/messages.de.xlf
@@ -45,6 +45,12 @@
         <source>close</source>
         <target>schließen</target>
       </trans-unit>
+      <trans-unit id="error-change-instance" datatype="html">
+        <source>Failed to change instance!</source>
+      </trans-unit>
+      <trans-unit id="error-change-instance-desc" datatype="html">
+        <source>An error occurred while trying to change the OctoPrint instance.</source>
+      </trans-unit>
       <trans-unit id="error-parsing-custom-action" datatype="html">
         <source>Error parsing custom action!</source>
         <target></target>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -45,6 +45,12 @@
         <source>close</source>
         <target>fermer</target>
       </trans-unit>
+      <trans-unit id="error-change-instance" datatype="html">
+        <source>Failed to change instance!</source>
+      </trans-unit>
+      <trans-unit id="error-change-instance-desc" datatype="html">
+        <source>An error occurred while trying to change the OctoPrint instance.</source>
+      </trans-unit>
       <trans-unit id="error-parsing-custom-action" datatype="html">
         <source>Error parsing custom action!</source>
         <target></target>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -79,46 +79,60 @@
           <context context-type="linenumber">139,146</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="error-change-instance" datatype="html">
+        <source>Failed to change instance!</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
+          <context context-type="linenumber">95</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="error-change-instance-desc" datatype="html">
+        <source>An error occurred while trying to change the OctoPrint instance.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
+          <context context-type="linenumber">96</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="error-parsing-custom-action" datatype="html">
         <source>Error parsing custom action!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
-          <context context-type="linenumber">138</context>
+          <context context-type="linenumber">150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-parsing-custom-action-desc" datatype="html">
         <source>Unable to parse the custom action.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
-          <context context-type="linenumber">139</context>
+          <context context-type="linenumber">151</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-custom-action-invalid" datatype="html">
         <source>Unknown special command!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
-          <context context-type="linenumber">162</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-custom-action-invalid-desc" datatype="html">
         <source>The special command you have entered is unknown.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
-          <context context-type="linenumber">163</context>
+          <context context-type="linenumber">175</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-custom-action-disabled" datatype="html">
         <source>Printer commands are not available!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
-          <context context-type="linenumber">178</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-custom-action-disabled-desc" datatype="html">
         <source>Please connect to your printer first before  attempting to use a printer command.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/components/action-center/action-center.component.ts</context>
-          <context context-type="linenumber">179</context>
+          <context context-type="linenumber">191</context>
         </context-group>
       </trans-unit>
       <trans-unit id="long-init" datatype="html">

--- a/src/services/change-instance.service.ts
+++ b/src/services/change-instance.service.ts
@@ -1,0 +1,20 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+
+import { BasePathService } from './base-path.service';
+import { ConfigService } from './config.service';
+
+@Injectable()
+export class ChangeInstanceService {
+  private http = inject(HttpClient);
+  private basePathService = inject(BasePathService);
+  private config = inject(ConfigService);
+
+  public changeInstance(instance) {
+    return this.http.post(
+      `${this.basePathService.getBasePath()}/plugin/octodash/api/change_instance`,
+      { instance },
+      this.config.getHTTPHeaders(),
+    );
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -2,6 +2,7 @@ import { HttpClient } from '@angular/common/http';
 
 import { AppService } from './app.service';
 import { BasePathService } from './base-path.service';
+import { ChangeInstanceService } from './change-instance.service';
 import { ConfigService } from './config.service';
 import { ConversionService } from './conversion.service';
 import { EnclosureOctoprintService } from './enclosure/enclosure.octoprint.service';
@@ -38,6 +39,7 @@ export default [
   OctoprintSettingsService,
   PluginsService,
   BasePathService,
+  ChangeInstanceService,
   [
     {
       provide: SystemService,

--- a/tests/test_change_instance.py
+++ b/tests/test_change_instance.py
@@ -5,13 +5,10 @@ from octoprint_octodash import OctodashPlugin
 
 
 @pytest.mark.parametrize("input, group", [
-    ("#this is a comment \n\nsomeothercommand\nchromium-browser --kiosk http://octopi.local", 'http://octopi.local'),
-    ("chromium-browser --kiosk https://example.com", 'https://example.com'),
-    ("chromium-browser --kiosk http://192.168.2.24:5000", 'http://192.168.2.24:5000'),
-    ("chromium-browser --kiosk http://192.168.2.24:5000/printerb", 'http://192.168.2.24:5000/printerb'),
-    ("chromium-browser --kiosk http://192.168.2.24:5000/printerb --something", 'http://192.168.2.24:5000/printerb'),
-    # ("someothercommand\nchromium-browser --kiosk octopi.local", 'octopi.local'),
-    # ("chromium-browser --kiosk octopi.local", "octopi.local"),
+    ("OCTOPRINT_URL=http://localhost:5000\nchromium-browser --kiosk http://octopi.local", 'http://localhost:5000'),
+    ("something\nOCTOPRINT_URL=http://localhost:5000\nchromium-browser --kiosk http://octopi.local\nsdf", 'http://localhost:5000'),
+    ("OCTOPRINT_URL=https://octopi.example.com", 'https://octopi.example.com'),
+    ('\nls\n\n# a commment\n\nOCTOPRINT_URL=http://localhost\n\nchromium-browser --kiosk $OCTOPRINT_URL/plugin/octodash\n\n', 'http://localhost')
 ])
 def test_change_regex(input, group):
     plugin = OctodashPlugin()
@@ -29,8 +26,9 @@ def test_change_regex_no_match(input):
     assert match is None
 
 @pytest.mark.parametrize("input, expected", [
-    ("chromium-browser --kiosk http://octopi.local someothercommand", "chromium-browser --kiosk http://new.local someothercommand"),
-    # ("someothercommand\nchromium-browser --kiosk http://octopi.local", "someothercommand\nchromium-browser --kiosk http://new.local"),
+    ("OCTOPRINT_URL=http://localhost:8080", "OCTOPRINT_URL=http://new.local"),
+    ("someothercommand\nOCTOPRINT_URL=http://localhost:8080", "someothercommand\nOCTOPRINT_URL=http://new.local"),
+    ('\nls\n\n# a commment\n\nOCTOPRINT_URL=http://localhost\n\nchromium-browser --kiosk $OCTOPRINT_URL/plugin/octodash\n\n', '\nls\n\n# a commment\n\nOCTOPRINT_URL=http://new.local\n\nchromium-browser --kiosk $OCTOPRINT_URL/plugin/octodash\n\n')
 ])
 def test_update_xinit_for_instance(input, expected):
     xinit = input

--- a/tests/test_change_instance.py
+++ b/tests/test_change_instance.py
@@ -30,7 +30,7 @@ def test_change_regex_no_match(input):
 
 @pytest.mark.parametrize("input, expected", [
     ("chromium-browser --kiosk http://octopi.local someothercommand", "chromium-browser --kiosk http://new.local someothercommand"),
-    ("someothercommand\nchromium-browser --kiosk http://octopi.local", "someothercommand\nchromium-browser --kiosk http://new.local"),
+    # ("someothercommand\nchromium-browser --kiosk http://octopi.local", "someothercommand\nchromium-browser --kiosk http://new.local"),
 ])
 def test_update_xinit_for_instance(input, expected):
     xinit = input

--- a/tests/test_change_instance.py
+++ b/tests/test_change_instance.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock, call
+import pytest
+
+from octoprint_octodash import OctodashPlugin
+
+
+@pytest.mark.parametrize("input, group", [
+    ("#this is a comment \n\nsomeothercommand\nchromium-browser --kiosk http://octopi.local", 'http://octopi.local'),
+    ("chromium-browser --kiosk https://example.com", 'https://example.com'),
+    ("chromium-browser --kiosk http://192.168.2.24:5000", 'http://192.168.2.24:5000'),
+    ("chromium-browser --kiosk http://192.168.2.24:5000/printerb", 'http://192.168.2.24:5000/printerb'),
+    ("chromium-browser --kiosk http://192.168.2.24:5000/printerb --something", 'http://192.168.2.24:5000/printerb'),
+    # ("someothercommand\nchromium-browser --kiosk octopi.local", 'octopi.local'),
+    # ("chromium-browser --kiosk octopi.local", "octopi.local"),
+])
+def test_change_regex(input, group):
+    plugin = OctodashPlugin()
+    match = plugin.change_instance.search(input)
+    assert match is not None
+    assert match.group(1) == group
+
+@pytest.mark.parametrize("input", [
+    "someothercommand\nchrsdfomium-browser --kiosk octopi.local",
+    "chromium-browasdfser --kiosk octopi.local",
+])
+def test_change_regex_no_match(input):
+    plugin = OctodashPlugin()
+    match = plugin.change_instance.search(input)
+    assert match is None
+
+@pytest.mark.parametrize("input, expected", [
+    ("chromium-browser --kiosk http://octopi.local someothercommand", "chromium-browser --kiosk http://new.local someothercommand"),
+    ("someothercommand\nchromium-browser --kiosk http://octopi.local", "someothercommand\nchromium-browser --kiosk http://new.local"),
+])
+def test_update_xinit_for_instance(input, expected):
+    xinit = input
+    plugin = OctodashPlugin()
+    new = plugin._update_xinit_for_instance(xinit, "http://new.local")
+    assert new == expected

--- a/tests/test_change_instance.py
+++ b/tests/test_change_instance.py
@@ -3,6 +3,11 @@ import pytest
 
 from octoprint_octodash import OctodashPlugin
 
+@pytest.fixture
+def plugin():
+    plugin = OctodashPlugin()
+    return plugin
+
 
 @pytest.mark.parametrize("input, group", [
     ("OCTOPRINT_URL=http://localhost:5000\nchromium-browser --kiosk http://octopi.local", 'http://localhost:5000'),
@@ -10,8 +15,7 @@ from octoprint_octodash import OctodashPlugin
     ("OCTOPRINT_URL=https://octopi.example.com", 'https://octopi.example.com'),
     ('\nls\n\n# a commment\n\nOCTOPRINT_URL=http://localhost\n\nchromium-browser --kiosk $OCTOPRINT_URL/plugin/octodash\n\n', 'http://localhost')
 ])
-def test_change_regex(input, group):
-    plugin = OctodashPlugin()
+def test_change_regex(plugin, input, group):
     match = plugin.change_instance.search(input)
     assert match is not None
     assert match.group(1) == group
@@ -20,8 +24,7 @@ def test_change_regex(input, group):
     "someothercommand\nchrsdfomium-browser --kiosk octopi.local",
     "chromium-browasdfser --kiosk octopi.local",
 ])
-def test_change_regex_no_match(input):
-    plugin = OctodashPlugin()
+def test_change_regex_no_match(plugin, input):
     match = plugin.change_instance.search(input)
     assert match is None
 
@@ -30,8 +33,7 @@ def test_change_regex_no_match(input):
     ("someothercommand\nOCTOPRINT_URL=http://localhost:8080", "someothercommand\nOCTOPRINT_URL=http://new.local"),
     ('\nls\n\n# a commment\n\nOCTOPRINT_URL=http://localhost\n\nchromium-browser --kiosk $OCTOPRINT_URL/plugin/octodash\n\n', '\nls\n\n# a commment\n\nOCTOPRINT_URL=http://new.local\n\nchromium-browser --kiosk $OCTOPRINT_URL/plugin/octodash\n\n')
 ])
-def test_update_xinit_for_instance(input, expected):
+def test_update_xinit_for_instance(plugin, input, expected):
     xinit = input
-    plugin = OctodashPlugin()
     new = plugin._update_xinit_for_instance(xinit, "http://new.local")
     assert new == expected

--- a/tests/test_change_instance.py
+++ b/tests/test_change_instance.py
@@ -10,10 +10,10 @@ def plugin():
 
 
 @pytest.mark.parametrize("input, group", [
-    ("OCTOPRINT_URL=http://localhost:5000\nchromium-browser --kiosk http://octopi.local", 'http://localhost:5000'),
-    ("something\nOCTOPRINT_URL=http://localhost:5000\nchromium-browser --kiosk http://octopi.local\nsdf", 'http://localhost:5000'),
-    ("   OCTOPRINT_URL=https://octopi.example.com", 'https://octopi.example.com'),
-    ('\nls\n\n# a commment\n\nOCTOPRINT_URL=http://localhost\n\nchromium-browser --kiosk $OCTOPRINT_URL/plugin/octodash\n\n', 'http://localhost')
+    ("export OCTOPRINT_URL=http://localhost:5000\nchromium-browser --kiosk http://octopi.local", 'http://localhost:5000'),
+    ("something\nexport OCTOPRINT_URL=http://localhost:5000\nchromium-browser --kiosk http://octopi.local\nsdf", 'http://localhost:5000'),
+    ("   export OCTOPRINT_URL=https://octopi.example.com", 'https://octopi.example.com'),
+    ('\nls\n\n# a commment\n\nexport OCTOPRINT_URL=http://localhost\n\nchromium-browser --kiosk $OCTOPRINT_URL/plugin/octodash\n\n', 'http://localhost')
 ])
 def test_change_regex(plugin, input, group):
     match = plugin.change_instance.search(input)
@@ -29,9 +29,9 @@ def test_change_regex_no_match(plugin, input):
     assert match is None
 
 @pytest.mark.parametrize("input, expected", [
-    ("OCTOPRINT_URL=http://localhost:8080", "OCTOPRINT_URL=http://new.local"),
-    ("someothercommand\nOCTOPRINT_URL=http://localhost:8080", "someothercommand\nOCTOPRINT_URL=http://new.local"),
-    ('\nls\n\n# a commment\n\nOCTOPRINT_URL=http://localhost\n\nchromium-browser --kiosk $OCTOPRINT_URL/plugin/octodash\n\n', '\nls\n\n# a commment\n\nOCTOPRINT_URL=http://new.local\n\nchromium-browser --kiosk $OCTOPRINT_URL/plugin/octodash\n\n')
+    ("export OCTOPRINT_URL=http://localhost:8080", "export OCTOPRINT_URL=http://new.local"),
+    ("someothercommand\nexport OCTOPRINT_URL=http://localhost:8080", "someothercommand\nexport OCTOPRINT_URL=http://new.local"),
+    ('\nls\n\n# a commment\n\nexport OCTOPRINT_URL=http://localhost\n\nchromium-browser --kiosk $OCTOPRINT_URL/plugin/octodash\n\n', '\nls\n\n# a commment\n\nexport OCTOPRINT_URL=http://new.local\n\nchromium-browser --kiosk $OCTOPRINT_URL/plugin/octodash\n\n')
 ])
 def test_update_xinit_for_instance(plugin, input, expected):
     xinit = input

--- a/tests/test_change_instance.py
+++ b/tests/test_change_instance.py
@@ -12,7 +12,7 @@ def plugin():
 @pytest.mark.parametrize("input, group", [
     ("OCTOPRINT_URL=http://localhost:5000\nchromium-browser --kiosk http://octopi.local", 'http://localhost:5000'),
     ("something\nOCTOPRINT_URL=http://localhost:5000\nchromium-browser --kiosk http://octopi.local\nsdf", 'http://localhost:5000'),
-    ("OCTOPRINT_URL=https://octopi.example.com", 'https://octopi.example.com'),
+    ("   OCTOPRINT_URL=https://octopi.example.com", 'https://octopi.example.com'),
     ('\nls\n\n# a commment\n\nOCTOPRINT_URL=http://localhost\n\nchromium-browser --kiosk $OCTOPRINT_URL/plugin/octodash\n\n', 'http://localhost')
 ])
 def test_change_regex(plugin, input, group):


### PR DESCRIPTION
Adding an endpoint to swap out the `OCTOPRINT_URL` defined in `.bashrc`, and a custom action for calling that.

Also includes:
* Using `sudo -n` on the commands so sudo doesn't prompt for a password we're not going to provide

Perhaps future work will incorporate this into the UI more natively.