### PR TITLE
feat: display spool ID in Spoolman filament selection screen

### DIFF
--- a/src/services/filament/spoolman.octoprint.service.ts
+++ b/src/services/filament/spoolman.octoprint.service.ts
@@ -61,7 +61,7 @@ export class SpoolmanOctoprintService implements FilamentPluginService {
       color: `#${spool.filament.color_hex}`,
       density: spool.filament.density,
       diameter: spool.filament.diameter,
-      displayName: `${spool.filament.vendor?.name || ''} - ${spool.filament.name || ''}`,
+      displayName: `#${spool.id} ${spool.filament.vendor?.name || ''} - ${spool.filament.name || ''}`,
       id: spool.id,
       material: spool.filament.material || '',
       name: spool.filament.name,


### PR DESCRIPTION
Follow-up to #5528 from @Hillshum - prepends the Spoolman spool ID to the display name shown in the filament selection screen (e.g., `#42 Prusament - PLA Galaxy Black`).

This makes it easier to identify spools when they are physically labeled by their Spoolman ID, like mine are, I only have the ID written on the spool.

### Changes
- Updated `displayName` in `SpoolmanOctoprintService.convertSpoolmanSpool()` to include the spool ID prefix.

### Question
Is showing the spool ID by default acceptable, or would you prefer this to be behind a configuration flag/setting? Happy to add an option for it if needed.