### PR TITLE
Fix bug preventing filament picker from indicating the currently selected spool

### DIFF
--- a/src/components/filament/choose-filament/choose-filament.component.html
+++ b/src/components/filament/choose-filament/choose-filament.component.html
@@ -4,7 +4,7 @@
     <table class="filaments">
       @for (spool of filament.filamentSpools; track spool) {
         <tr
-          [ngClass]="{ 'filaments__in-use': currentSpools.includes(spool.id) }"
+          [ngClass]="{ 'filaments__in-use': currentSpools().includes(spool.id) }"
           long-press
           matRipple
           [matRippleUnbounded]="false"
@@ -13,8 +13,8 @@
           (onShortPress)="setSpool(spool)"
           (onLongPressing)="setSpoolSkipChange(spool)">
           <td class="filaments__in-use-icon">
-            @if (currentSpools.includes(spool.id)) {
-              <app-hotend-icon [tool]="currentSpools.indexOf(spool.id)" />
+            @if (currentSpools().includes(spool.id)) {
+              <app-hotend-icon [tool]="currentSpools().indexOf(spool.id)" />
             }
           </td>
           <td class="filaments__type">

--- a/src/components/filament/choose-filament/choose-filament.component.ts
+++ b/src/components/filament/choose-filament/choose-filament.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Output, signal, WritableSignal } from '@angular/core';
 import { map } from 'rxjs/operators';
 
 import { FilamentSpool } from '../../../model';
@@ -13,13 +13,13 @@ import { FilamentService } from '../../../services/filament/filament.service';
 export class ChooseFilamentComponent {
   @Output() spoolChange = new EventEmitter<{ spool: FilamentSpool; skipChange: boolean }>();
 
-  private currentSpools: (number | null)[];
+  private currentSpools: WritableSignal<(number | null)[]> = signal([]);
 
   constructor(public filament: FilamentService) {
     filament
       .getCurrentSpools()
       .pipe(map(spools => spools.map(s => s?.id || null)))
-      .subscribe(ids => (this.currentSpools = ids));
+      .subscribe(ids => this.currentSpools.set(ids));
   }
 
   public getSpoolWeightLeft(weight: number, used: number): number {

--- a/src/components/filament/choose-filament/choose-filament.component.ts
+++ b/src/components/filament/choose-filament/choose-filament.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Output } from '@angular/core';
+import { map } from 'rxjs/operators';
 
 import { FilamentSpool } from '../../../model';
 import { FilamentService } from '../../../services/filament/filament.service';
@@ -15,7 +16,10 @@ export class ChooseFilamentComponent {
   private currentSpools: (number | null)[];
 
   constructor(public filament: FilamentService) {
-    this.currentSpools = (filament.getCurrentSpools() || []).map(s => s?.id || null);
+    filament
+      .getCurrentSpools()
+      .pipe(map(spools => spools.map(s => s?.id || null)))
+      .subscribe(ids => (this.currentSpools = ids));
   }
 
   public getSpoolWeightLeft(weight: number, used: number): number {

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -1935,42 +1935,42 @@
         <source>Can&apos;t load filament spools!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/services/filament/filament.service.ts</context>
-          <context context-type="linenumber">29</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-spool" datatype="html">
         <source>Can&apos;t load active spool!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/services/filament/filament.service.ts</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">36</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-spool-id" datatype="html">
         <source>Spool IDs didn&apos;t match</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/services/filament/filament.service.ts</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">65</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-change-spool" datatype="html">
         <source>Can&apos;t change spool. Please change spool manually in the OctoPrint UI.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/services/filament/filament.service.ts</context>
-          <context context-type="linenumber">65</context>
+          <context context-type="linenumber">66</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-set-new-spool" datatype="html">
         <source>Can&apos;t set new spool!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/services/filament/filament.service.ts</context>
-          <context context-type="linenumber">71</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="error-set-new-spool-2" datatype="html">
         <source>Can&apos;t set new spool!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/services/filament/filament.service.ts</context>
-          <context context-type="linenumber">77</context>
+          <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="local" datatype="html">

--- a/src/services/filament/filament.service.ts
+++ b/src/services/filament/filament.service.ts
@@ -1,5 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
 
 import { FilamentSpool } from '../../model';
 import { ConfigService } from '../../services/config.service';
@@ -9,7 +10,7 @@ import { FilamentPluginService } from './filament-plugin.service';
 @Injectable()
 export class FilamentService {
   private filamentSpools: Array<FilamentSpool>;
-  private currentSpool: FilamentSpool[];
+  private currentSpool = new BehaviorSubject<Array<FilamentSpool>>([]);
   private loading = true;
 
   constructor(
@@ -30,7 +31,7 @@ export class FilamentService {
       complete: () => (this.loading = false),
     });
     this.filamentPluginService.getCurrentSpools().subscribe({
-      next: (spools: FilamentSpool[]) => (this.currentSpool = spools),
+      next: (spools: FilamentSpool[]) => this.currentSpool.next(spools),
       error: (error: HttpErrorResponse) =>
         this.notificationService.warn($localize`:@@error-spool:Can't load active spool!`, error.message),
     });
@@ -40,8 +41,8 @@ export class FilamentService {
     return this.filamentSpools;
   }
 
-  public getCurrentSpools(): Array<FilamentSpool> {
-    return this.currentSpool;
+  public getCurrentSpools() {
+    return this.currentSpool.asObservable();
   }
 
   public getCurrentSpool(tool: number): FilamentSpool {


### PR DESCRIPTION
This fixes a race condition that prevented the filament picker from indicating the currently selected spool. 

This issue only happened with single-filament printers, as the tool picker allowed time for the current selection to be fetched from OctoPrint. 

Fixed behavior (yes looks like the positioning of the icon needs improvement):
<img width="1092" height="565" alt="Screenshot 2026-04-28 at 5 44 09 PM" src="https://github.com/user-attachments/assets/bc3a3547-45ea-4980-9db7-db723aafcfcf" />
