### PR TITLE
Allow tapping on temp in picker to set to zero

### DIFF
--- a/src/components/shared/quick-control/quick-control.component.html
+++ b/src/components/shared/quick-control/quick-control.component.html
@@ -7,7 +7,7 @@
       </div>
     </div>
 
-    <div class="quick-control-value" colspan="2" (click)="changeValue(-1000)" matRipple [matRippleUnbounded]="false">
+    <div class="quick-control-value" colspan="2" (click)="changeValue(0)" matRipple [matRippleUnbounded]="false">
       {{ value }}<span class="quick-control-value-unit">{{ unit }}</span>
     </div>
 


### PR DESCRIPTION
Apparently this worked with very old versions but was broken in refactors

Fixes #5692 